### PR TITLE
Add scrollytelling layout for block-data talk

### DIFF
--- a/src/components/mdx/ScrollyTalkSection.astro
+++ b/src/components/mdx/ScrollyTalkSection.astro
@@ -1,0 +1,315 @@
+---
+import { Picture } from "astro:assets";
+import type { ImageMetadata } from "astro";
+
+interface Props {
+	images: string[];
+}
+
+const { images } = Astro.props;
+
+// Generate unique ID
+const sectionId = `scrolly-${Math.random().toString(36).slice(2, 9)}`;
+
+// Detect video URLs by file extension
+const isVideo = (src: string) => /\.(mp4|webm|mov)(\?.*)?$/i.test(src);
+
+// Reuse TalkSlide's glob-based image resolution
+const imageGlobs = import.meta.glob<{ default: ImageMetadata }>(
+	"/src/images/**/*",
+);
+
+const resolvedImages = await Promise.all(
+	images.map(async (src) => {
+		if (isVideo(src)) {
+			return { src, isRemote: true, resolved: null, isVideo: true };
+		}
+		const isRemote = src.startsWith("http://") || src.startsWith("https://");
+		if (isRemote) {
+			return { src, isRemote: true, resolved: null, isVideo: false };
+		}
+		const globKey = "/src" + src;
+		if (!imageGlobs[globKey]) {
+			console.warn(`ScrollyTalkSection: Image not found: ${src}`);
+			return { src, isRemote: true, resolved: null, isVideo: false };
+		}
+		const resolved = (await imageGlobs[globKey]()).default;
+		return { src, isRemote: false, resolved, isVideo: false };
+	}),
+);
+
+const widths = [600, 900, 1200];
+---
+
+<div class="scrolly-section" data-scrolly-id={sectionId}>
+	<!-- Desktop: sticky image panel -->
+	<div class="scrolly-images">
+		<div class="image-stack">
+			{
+				resolvedImages.map((img, i) =>
+					img.isVideo ? (
+						<video
+							class={`scrolly-img scrolly-video ${i === 0 ? "active" : ""}`}
+							data-img-index={i}
+							src={img.src}
+							muted
+							loop
+							playsinline
+							controls
+							preload="metadata"
+						/>
+					) : img.isRemote || !img.resolved ? (
+						<img
+							class={`scrolly-img ${i === 0 ? "active" : ""}`}
+							data-img-index={i}
+							src={img.src}
+							alt=""
+							loading="lazy"
+						/>
+					) : (
+						<Picture
+							class={`scrolly-img ${i === 0 ? "active" : ""}`}
+							data-img-index={i}
+							src={img.resolved}
+							alt=""
+							widths={widths}
+							formats={["avif", "webp", "jpg"]}
+						/>
+					),
+				)
+			}
+		</div>
+	</div>
+
+	<!-- Scrolling text with mobile images interleaved -->
+	<div class="scrolly-text">
+		{
+			resolvedImages.map((img, i) => (
+				<div class="mobile-image" data-for-slide={i} style={`order: ${i * 2}`}>
+					{img.isVideo ? (
+						<video
+							src={img.src}
+							muted
+							loop
+							playsinline
+							controls
+							preload="metadata"
+						/>
+					) : img.isRemote || !img.resolved ? (
+						<img src={img.src} alt="" loading="lazy" />
+					) : (
+						<Picture
+							src={img.resolved}
+							alt=""
+							widths={widths}
+							formats={["avif", "webp", "jpg"]}
+						/>
+					)}
+				</div>
+			))
+		}
+		<slot />
+	</div>
+</div>
+
+<!-- Dynamic mobile ordering rules scoped to this section -->
+<style is:inline set:html={`
+@media (max-width: 1200px) {
+${images.map((_, i) => `  [data-scrolly-id="${sectionId}"] .scrolly-text [data-slide="${i}"] { order: ${i * 2 + 1}; }`).join('\n')}
+}
+`} />
+
+<script>
+	import scrollama from "scrollama";
+
+	const scrollers: any[] = [];
+
+	function initAllScrollySections() {
+		scrollers.forEach((s) => s.destroy());
+		scrollers.length = 0;
+
+		document.querySelectorAll("[data-scrolly-id]").forEach((section) => {
+			const images = section.querySelectorAll(".scrolly-img");
+			const steps = section.querySelectorAll("[data-slide]");
+			if (steps.length === 0 || images.length === 0) return;
+
+			const scroller = scrollama();
+			scroller
+				.setup({
+					step: steps as unknown as string,
+					offset: 0.5,
+				})
+				.onStepEnter((response: any) => {
+					const slideIndex = parseInt(
+						response.element.getAttribute("data-slide"),
+						10,
+					);
+					images.forEach((img, i) => {
+						const isActive = i === slideIndex;
+						img.classList.toggle("active", isActive);
+						// Auto-play/pause videos on slide transition
+						if (img.tagName === "VIDEO") {
+							const video = img as HTMLVideoElement;
+							if (isActive) {
+								video.play().catch(() => {});
+							} else {
+								video.pause();
+							}
+						}
+					});
+				});
+
+			scrollers.push(scroller);
+		});
+	}
+
+	initAllScrollySections();
+
+	const handleResize = () => scrollers.forEach((s) => s.resize());
+	window.addEventListener("resize", handleResize);
+
+	document.querySelectorAll(".scrolly-img").forEach((img) => {
+		img.addEventListener("load", handleResize);
+	});
+
+	document.addEventListener("astro:page-load", initAllScrollySections);
+
+	const cleanup = () => {
+		scrollers.forEach((s) => s.destroy());
+		scrollers.length = 0;
+		window.removeEventListener("resize", handleResize);
+	};
+	document.addEventListener("astro:before-swap", cleanup);
+	document.addEventListener("astro:unmount", cleanup);
+</script>
+
+<style>
+	.scrolly-section {
+		grid-column: 1 / 4 !important;
+		display: grid;
+		grid-template-columns: 3fr 2fr;
+		gap: var(--space-l);
+		max-width: 1400px;
+		margin: var(--space-xl) auto;
+		padding: 0 var(--space-xs);
+	}
+
+	/* --- Left: sticky image panel --- */
+	.scrolly-images {
+		position: sticky;
+		top: 48px;
+		height: calc(100vh - 96px);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.image-stack {
+		position: relative;
+		width: 100%;
+		aspect-ratio: 16 / 9;
+	}
+
+	.scrolly-img,
+	.image-stack :global(picture) {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+	}
+
+	.scrolly-img {
+		object-fit: contain;
+		border-radius: var(--border-radius-sm);
+		border: 1px solid var(--color-gray-100);
+		box-shadow: var(--box-shadow-sm);
+		opacity: 0;
+		transition: opacity 0.6s ease-out;
+	}
+
+	.scrolly-img.active {
+		opacity: 1;
+	}
+
+	/* Make img inside <picture> fill the container */
+	.image-stack :global(picture img) {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+		border-radius: var(--border-radius-sm);
+		border: 1px solid var(--color-gray-100);
+		box-shadow: var(--box-shadow-sm);
+	}
+
+	/* --- Right: scrolling text --- */
+	.scrolly-text :global([data-slide]) {
+		min-height: 75vh;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		padding: var(--space-xl) var(--space-m);
+	}
+
+	.scrolly-text :global([data-slide="0"]) {
+		justify-content: flex-start;
+		padding-top: calc(50vh - 200px);
+	}
+
+	.scrolly-text :global([data-slide] p) {
+		font-size: var(--font-size-base);
+		line-height: var(--leading-looser);
+		margin-bottom: 1rem;
+	}
+
+	.scrolly-text :global([data-slide] p:last-child) {
+		margin-bottom: 0;
+	}
+
+	/* Mobile images hidden on desktop */
+	.mobile-image {
+		display: none;
+	}
+
+	.mobile-image :global(img),
+	.mobile-image :global(video) {
+		width: 100%;
+		height: auto;
+		border-radius: var(--border-radius-sm);
+		border: 1px solid var(--color-gray-100);
+		box-shadow: var(--box-shadow-sm);
+	}
+
+	/* === Mobile: stacked layout === */
+	@media (max-width: 1200px) {
+		.scrolly-section {
+			grid-template-columns: 1fr;
+			gap: var(--space-s);
+			max-width: 900px;
+		}
+
+		.scrolly-images {
+			display: none;
+		}
+
+		.scrolly-text {
+			display: flex;
+			flex-direction: column;
+		}
+
+		.mobile-image {
+			display: block;
+			margin-bottom: var(--space-s);
+		}
+
+		.scrolly-text :global([data-slide]) {
+			min-height: auto;
+			padding: var(--space-m) 0;
+		}
+
+		/* Override first-slide desktop offset */
+		.scrolly-text :global([data-slide="0"]) {
+			justify-content: flex-start;
+			padding-top: var(--space-m);
+		}
+	}
+</style>

--- a/src/components/mdx/ScrollyTalkSection.astro
+++ b/src/components/mdx/ScrollyTalkSection.astro
@@ -163,16 +163,19 @@ ${images.map((_, i) => `  [data-scrolly-id="${sectionId}"] .scrolly-text [data-s
 		});
 	}
 
-	initAllScrollySections();
-
 	const handleResize = () => scrollers.forEach((s) => s.resize());
-	window.addEventListener("resize", handleResize);
 
-	document.querySelectorAll(".scrolly-img").forEach((img) => {
-		img.addEventListener("load", handleResize);
-	});
+	function initAndAttachListeners() {
+		initAllScrollySections();
+		window.addEventListener("resize", handleResize);
+		document.querySelectorAll(".scrolly-img").forEach((img) => {
+			img.addEventListener("load", handleResize);
+		});
+	}
 
-	document.addEventListener("astro:page-load", initAllScrollySections);
+	initAndAttachListeners();
+
+	document.addEventListener("astro:page-load", initAndAttachListeners);
 
 	const cleanup = () => {
 		scrollers.forEach((s) => s.destroy());

--- a/src/content/talks/block-data.mdx
+++ b/src/content/talks/block-data.mdx
@@ -21,6 +21,7 @@ import AssumedAudience from "../../components/mdx/AssumedAudience.astro";
 import Video from "../../components/mdx/Video.astro";
 import Center from "../../components/mdx/Center.astro";
 import TalkSlide from "../../components/mdx/TalkSlide.astro";
+import ScrollyTalkSection from "../../components/mdx/ScrollyTalkSection.astro";
 import YearsAgo from "../../components/mdx/YearsAgo.astro";
 
 <AssumedAudience>
@@ -55,672 +56,659 @@ Here's the original video recording. You can also read the full written version 
 	margin="1rem auto"
 />
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-4_tndnxv.jpg">
+<ScrollyTalkSection images={[
+  "/images/posts/block-data/block-data-4_tndnxv.jpg",
+  "/images/posts/block-data/block-data-5_itjpbg.jpg",
+  "/images/posts/block-data/block-data-6_mt4aok.jpg",
+  "/images/posts/block-data/block-data-7_fdmgh0.jpg",
+  "/images/posts/block-data/block-data-8_szhwdl.jpg",
+  "/images/posts/block-data/block-data-9_ifcfyz.jpg",
+  "/images/posts/block-data/block-data-10_shos2b.jpg",
+  "/images/posts/block-data/block-data-11_dbmo8h.jpg",
+  "/images/posts/block-data/block-data-12_hovbek.jpg",
+  "/images/posts/block-data/block-data-13_ysdsye.jpg",
+  "/images/posts/block-data/block-data-84_nbfyv2.jpg",
+  "/images/posts/block-data/block-data-85_pg0ypo.jpg",
+  "/images/posts/block-data/block-data-86_nchcdq.jpg",
+  "/images/posts/block-data/block-data-14_b9eqty.jpg",
+  "/images/posts/block-data/block-data-15_nqgsgj.jpg",
+  "/images/posts/block-data/block-data-16_iaudhy.jpg",
+  "/images/posts/block-data/block-data-17_rcmfnr.jpg",
+  "/images/posts/block-data/block-data-18_uaojs7.jpg",
+  "/images/posts/block-data/block-data-19_auycdd.jpg",
+  "/images/posts/block-data/block-data-20_jlaudh.jpg",
+  "/images/posts/block-data/block-data-21_y19gvo.jpg",
+  "/images/posts/block-data/block-data-22_xs3qqw.jpg",
+  "/images/posts/block-data/block-data-23_mk6zve.jpg",
+  "/images/posts/block-data/block-data-24_aazqtv.jpg",
+  "/images/posts/block-data/block-data-25_j8hzy2.jpg",
+  "/images/posts/block-data/block-data-26_b0j2kx.jpg",
+  "/images/posts/block-data/block-data-27_rh3ste.jpg",
+  "/images/posts/block-data/block-data-28_m4jhd7.jpg",
+  "/images/posts/block-data/block-data-29_cl95ex.jpg",
+  "/images/posts/block-data/block-data-30_rjmqly.jpg",
+  "https://res.cloudinary.com/dxj9qr5gj/video/upload/ac_none,q_auto:best/v1654118527/maggieappleton.com/notes/block-data/notion_dah06m.mp4",
+  "https://res.cloudinary.com/dxj9qr5gj/video/upload/ac_none,q_auto:best/v1654118525/maggieappleton.com/notes/block-data/coda_rwocpi.mp4",
+  "/images/posts/block-data/block-data-31_vwgy0a.jpg",
+  "/images/posts/block-data/block-data-32_gpzcay.jpg",
+  "/images/posts/block-data/block-data-33_xgfffh.jpg",
+  "/images/posts/block-data/block-data-34_rcbzi2.jpg",
+  "/images/posts/block-data/block-data-35_anqzil.jpg",
+  "/images/posts/block-data/block-data-36_zmgcoy.jpg",
+  "/images/posts/block-data/block-data-37_gutn96.jpg",
+  "/images/posts/block-data/block-data-38_iwgjur.jpg",
+  "/images/posts/block-data/block-data-39_qlhmtc.jpg",
+  "/images/posts/block-data/block-data-40_i731dr.png",
+  "/images/posts/block-data/block-data-41_ee5eyc.jpg",
+  "/images/posts/block-data/block-data-42_hqkc7z.jpg",
+  "/images/posts/block-data/block-data-44_lmlej2.jpg",
+  "/images/posts/block-data/block-data-45_ufwbj5.jpg",
+  "/images/posts/block-data/block-data-46_mapaxa.jpg",
+  "/images/posts/block-data/block-data-47_vceg1j.jpg",
+  "/images/posts/block-data/block-data-48_djteby.jpg",
+  "/images/posts/block-data/block-data-49_povv3i.jpg",
+  "/images/posts/block-data/block-data-50_wgxc0k.jpg",
+  "/images/posts/block-data/block-data-51_kmfrfo.jpg",
+  "/images/posts/block-data/block-data-52_df4uha.jpg",
+  "/images/posts/block-data/block-data-53_q0cxdl.jpg",
+  "/images/posts/block-data/block-data-54_pfeg1o.jpg",
+  "/images/posts/block-data/block-data-55_r98d9x.jpg",
+  "/images/posts/block-data/react_component_-_npm_search_fg9sue.png",
+  "/images/posts/block-data/block-data-57_cgr1cm.jpg",
+  "/images/posts/block-data/block-data-58_agaokt.jpg",
+  "/images/posts/block-data/block-data-59_hq22zu.jpg",
+  "/images/posts/block-data/block-data-60_tnuksm.jpg",
+  "/images/posts/block-data/block-data-61_ezuhhs.jpg",
+  "/images/posts/block-data/block-data-62_xnoncm.jpg",
+  "/images/posts/block-data/block-data.001_x4vw74.jpg",
+  "/images/posts/block-data/block-data.002_nalvgm.jpg",
+  "/images/posts/block-data/block-data-66_nn0ctp.jpg",
+  "/images/posts/block-data/block-data-67_lecmbn.jpg",
+  "/images/posts/block-data/block-data-68_c3qm9o.jpg",
+  "/images/posts/block-data/block-data-69_evpdsa.jpg",
+  "/images/posts/block-data/block-data-70_svbws9.jpg",
+  "/images/posts/block-data/block-data-71_sqoqil.jpg",
+  "/images/posts/block-data/block-data-72_ddmtbq.jpg",
+  "/images/posts/block-data/block-data-73_rvfepe.jpg",
+  "/images/posts/block-data/block-data-74_gbsnzv.jpg",
+  "/images/posts/block-data/block-data-75_yz2dsb.jpg",
+  "/images/posts/block-data/block-data-76_qeyxil.jpg",
+  "/images/posts/block-data/block-data-77_z3mzp3.jpg",
+  "/images/posts/block-data/block-data-78_slbtws.jpg",
+  "/images/posts/block-data/block-data-79_zi4f24.jpg",
+  "/images/posts/block-data/block-data-80_shsciy.jpg",
+  "/images/posts/block-data/block-data-81_wzdywu.jpg",
+  "/images/posts/block-data/block-data-82_amfyan.jpg",
+  "/images/posts/block-data/block-data-83_hj9yb9.jpg",
+]}>
+<div data-slide="0">
+
+  I like the give the punchline away early in my talks. I'm here to convince you of a thesis – that block-based interfaces can help us create _more_ structured data on the web.
+
+  </div>
+  <div data-slide="1">
+
+  We're going to tackle this in four parts; we'll first clarify _why_ we should care about structured data at all. We'll then look at the rise of **block-based interfaces** – a design pattern that's become incredibly popular over the last 5 years. We'll then consider some current problems with block-based interfaces. And finally we'll explore a [protocol](https://blockprotocol.org) that we've been working on at [HASH](https://hash.ai). The goal of it is to address many of these problems both with blocks and structured data.
+
+  </div>
+  <div data-slide="2">
+
+  First, why is it worth dreaming about a world where we have _more_ structured data than right now?
+
+  </div>
+  <div data-slide="3">
 
-I like the give the punchline away early in my talks. I'm here to convince you of a thesis – that block-based interfaces can help us create _more_ structured data on the web.
+  "Structured data" means different things in different contexts, but here I'm specifically going to be talking about structured data on the web in this talk.
 
-</TalkSlide>
+  The web is filled with content – blog posts, descriptions, images, headlines, videos, and all the rest of it. But for the most part, our computers have no clue what that content is about. That's because it's _unstructured_. Meaning we haven't labelled the content in a way that makes sense to computers. In short, this content doesn't have good metadata.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-5_itjpbg.jpg">
+  </div>
+  <div data-slide="4">
 
-We're going to tackle this in four parts; we'll first clarify _why_ we should care about structured data at all. We'll then look at the rise of **block-based interfaces** – a design pattern that's become incredibly popular over the last 5 years. We'll then consider some current problems with block-based interfaces. And finally we'll explore a [protocol](https://blockprotocol.org) that we've been working on at [HASH](https://hash.ai). The goal of it is to address many of these problems both with blocks and structured data.
+  So if I wanted to search the web for content on Ted Chiang's book [Exhalation](https://en.wikipedia.org/wiki/Exhalation:_Stories) (a great read, by the way)...
 
-</TalkSlide>
+  </div>
+  <div data-slide="5">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-6_mt4aok.jpg"
->
+  And I do a standard text search for "exhalation", I'll get _some_ results about the book. But I'm just as likely to get results about breathing techniques or medical issues. The computer doesn't know the difference between Exhalation the book, and exhalation the biological concept. But we can fix this...
 
-First, why is it worth dreaming about a world where we have _more_ structured data than right now?
+  </div>
+  <div data-slide="6">
 
-</TalkSlide>
+  ...by adding structured data. This simply means labelling this content in a way computers can understand. We can programmatically declare a type on it.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-7_fdmgh0.jpg"
->
+  In this case, we would declare the type "book" and declare it's properties and their expected types. So we would expect a book to have a _title_ which is going to be a text string. And an _ISBN number_, which is going to be a number.
 
-“Structured data” means different things in different contexts, but here I'm specifically going to be talking about structured data on the web in this talk.
+  We typically call this type of structure a _schema_ – it's a data format describing a human concept (such as Book, Person, Movie, Recipe) that declares a set of expected properties and their types.
 
-The web is filled with content – blog posts, descriptions, images, headlines, videos, and all the rest of it. But for the most part, our computers have no clue what that content is about. That's because it's _unstructured_. Meaning we haven't labelled the content in a way that makes sense to computers. In short, this content doesn't have good metadata.
+  Some of these properties will be types that have their own properties. For examples, the _author_ which is of the type _Person_. Person is going to have properties like a name, a birthday, a job title. Similarly, the property _publisher_ is going to be of the type _Company_.
 
-</TalkSlide>
+  </div>
+  <div data-slide="7">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-8_szhwdl.jpg"
->
+  To give you a practical example of what this looks like, this is what unstructured data might look like for a website about this conference. We have the title in an `<h1>` tag and the description, times, and location in `<p>` tags.
 
-So if I wanted to search the web for content on Ted Chiang's book [Exhalation](https://en.wikipedia.org/wiki/Exhalation:_Stories) (a great read, by the way)...
+  As far as the computer knows, this content is a bunch of mystery nonsense. It's human-readable but not machine-readable.
 
-</TalkSlide>
+  </div>
+  <div data-slide="8">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-9_ifcfyz.jpg"
->
+  In contrast, this is what it would look like as structured data. This is the same event written up in JSON-LD (JSON Linked Data), which is currently the most popular and widely used format across the web.
 
-And I do a standard text search for “exhalation”, I'll get _some_ results about the book. But I'm just as likely to get results about breathing techniques or medical issues. The computer doesn't know the difference between Exhalation the book, and exhalation the biological concept. But we can fix this...
+  We can see it declares that this thing is of the type _Event_, and has properties like a start date and an end date. It also has a location which is of the type _Place_, which in turn has an _Address_.
 
-</TalkSlide>
+  </div>
+  <div data-slide="9">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-10_shos2b.jpg"
->
+  At this point, some people are thinking this all sounds very familiar. What I'm describing is the semantic web.
 
-...by adding structured data.
-This simply means labelling this content in a way computers can understand. We can programmatically declare a type on it.
+  The semantic web is a dream that began over 20 years ago when Tim Berners-Lee wrote [an article](https://www.researchgate.net/publication/225070375_The_Semantic_Web_A_New_Form_of_Web_Content_That_is_Meaningful_to_Computers_Will_Unleash_a_Revolution_of_New_Possibilities) describing the possibilities of a web that could be read by machines.
 
-In this case, we would declare the type “book” and declare it's properties and their expected types. So we would expect a book to have a _title_ which is going to be a text string. And an _ISBN number_, which is going to be a number.
+  This dream, that the whole web would become interoperable structured data, promised a bright future of frictionless automation and rich user experiences.
 
-We typically call this type of structure a _schema_ – it's a data format describing a human concept (such as Book, Person, Movie, Recipe) that declares a set of expected properties and their types.
+  It's a beautiful dream, but to put it lightly, it's become complicated. The dream is enormously ambitious. And it's run into a number of problems since the original proposition.
 
-Some of these properties will be types that have their own properties. For examples, the _author_ which is of the type _Person_. Person is going to have properties like a name, a birthday, a job title. Similarly, the property _publisher_ is going to be of the type _Company_.
+  At this point I'll say I'm _not_ a semantic web expect, and this is a very touchy area, so I'll tread lightly. But there are a number of well known issues most people agree upon...
 
-</TalkSlide>
+  </div>
+  <div data-slide="10">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-11_dbmo8h.jpg"
->
+  <p>
+  First, ontologies – meaning the schemas we define for types like "Person" or "Book" – are always culturally relative and subjective. There is no universal single set of properties we can all agree upon. This is because human culture is inherently pluralistic. That's perhaps the whole point of human culture. It's a mechanism to create wildly diverse ways of seeing and being in the world. So diverse it makes it impossible to agree on fundamental categories and properties for what exists around us.
+  </p>
 
-To give you a practical example of what this looks like, this is what unstructured data might look like for a website about this conference. We have the title in an `<h1>` tag and the description, times, and location in `<p>` tags.
+  Take the type "Person" for example. On [schema.org](https://schema.org), the
+  largest and widely used repository of schemas (maintained by Google), a
+  _Person_ has the properties _first name_ and _last name_. But in a great many
+  cultures, people do not have first and last names. That's not how they name
+  people. People may have multiple personal names, family names, and clan names
+  that change depending on who is addressing them and in what context. None of
+  these fit neatly into two boxes on a form.
 
-As far as the computer knows, this content is a bunch of mystery nonsense. It's human-readable but not machine-readable.
+  Similarly, the type _Postal Address_ might seem like something with a rigid
+  structure. In places like the United Kingdom, we have strict formats for house
+  numbers, street names, and postal codes. But in some places, street addresses
+  have not been standardised and formalised by their governments. Someone's
+  address might be "go 200 meters past the temple and it's the fourth house on
+  the left." Try putting that into your schema.
 
-</TalkSlide>
+  </div>
+  <div data-slide="11">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-12_hovbek.jpg"
->
+  <p>The second issue is competing formats. Over the years people have proposed many different ways to implement structured data on the web. There's <a href="https://en.wikipedia.org/wiki/Resource_Description_Framework">RDF</a> and RDFa, <a href="https://en.wikipedia.org/wiki/JSON-LD">JSON-LD</a>, and <a href="https://en.wikipedia.org/wiki/Microformat">Microformats</a></p>
 
-In contrast, this is what it would look like as structured data. This is the same event written up in JSON-LD (JSON Linked Data), which is currently the most popular and widely used format across the web.
+  Then there are all the annotation frameworks, query languages, and vocabularies that interact with these formats like [OWL](https://en.wikipedia.org/wiki/Web_Ontology_Language), [FOAF](<https://en.wikipedia.org/wiki/FOAF_(ontology)>), [SPARQL](https://en.wikipedia.org/wiki/SPARQL), [Turtle](<https://en.wikipedia.org/wiki/Turtle_(syntax)>), and more.
 
-We can see it declares that this thing is of the type _Event_, and has properties like a start date and an end date. It also has a location which is of the type _Place_, which in turn has an _Address_.
+  You are probably overwhelmed by that list, and so are all the developers who are supposed to use them to make the dream of the semantic web come to life. It's not surprising most developers don't bother adding structured data to their sites.
 
-</TalkSlide>
+  </div>
+  <div data-slide="12">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-13_ysdsye.jpg"
->
+  Third, there are incentive issues. It takes a lot of developer labour to add semantic markup to a website, and doesn't offer immediate benefits in return. Structured data can certainly improve SEO and content discovery, but beyond that we haven't found enough compelling use cases for it.
 
-At this point, some people are thinking this all sounds very familiar. What I'm describing is the semantic web.
+  </div>
+  <div data-slide="13">
 
-The semantic web is a dream that began over 20 years ago when Tim Berners-Lee wrote [an article](https://www.researchgate.net/publication/225070375_The_Semantic_Web_A_New_Form_of_Web_Content_That_is_Meaningful_to_Computers_Will_Unleash_a_Revolution_of_New_Possibilities) describing the possibilities of a web that could be read by machines.
+  <p>Lastly, the ambitious scale of the semantic web compounds all the above problems. Trying to structure data across the <i>entire web</i> leads to issues of complexity.</p>
 
-This dream, that the whole web would become interoperable structured data, promised a bright future of frictionless automation and rich user experiences.
+  All these problems have made a lot of people skeptical about the feasibility of the semantic web. They're quite keen to throw the baby out with the bathwater.
 
-It's a beautiful dream, but to put it lightly, it's become complicated. The dream is enormously ambitious. And it's run into a number of problems since the original proposition.
+  </div>
+<div data-slide="14">
 
-At this point I'll say I'm _not_ a semantic web expect, and this is a very touchy area, so I'll tread lightly. But there are a number of well known issues most people agree upon...
+  The debate about the semantic web has devolved into an unhelpful binary.
 
-</TalkSlide>
+  On one side we have people insisting that structured data on the web has failed and will never work.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-84_nbfyv2.jpg"
->
- 
-<p>
-First, ontologies – meaning the schemas we define for types like “Person” or “Book” – are always culturally relative and subjective. There is no universal single set of properties we can all agree upon. This is because human culture is inherently pluralistic. That's perhaps the whole point of human culture. It's a mechanism to create wildly diverse ways of seeing and being in the world. So diverse it makes it impossible to agree on fundamental categories and properties for what exists around us.
-</p>
+  And on the other side we have people who are adamant that we need to fulfil the dream of a fully semantic web.
 
-Take the type “Person” for example. On [schema.org](https://schema.org), the
-largest and widely used repository of schemas (maintained by Google), a
-_Person_ has the properties _first name_ and _last name_. But in a great many
-cultures, people do not have first and last names. That's not how they name
-people. People may have multiple personal names, family names, and clan names
-that change depending on who is addressing them and in what context. None of
-these fit neatly into two boxes on a form.
+  This conversation doesn't leave a lot of room for nuance.
 
-Similarly, the type _Postal Address_ might seem like something with a rigid
-structure. In places like the United Kingdom, we have strict formats for house
-numbers, street names, and postal codes. But in some places, street addresses
-have not been standardised and formalised by their governments. Someone's
-address might be “go 200 meters past the temple and it's the fourth house on
-the left.” Try putting that into your schema.
+  </div>
+  <div data-slide="15">
 
-</TalkSlide>
+  What's we're missing here is the sensible middle ground of opportunity. There's plenty of value in pursuing structured data at a smaller scale. It's much easier to agree upon and maintain ontologies within companies, sets of companies, academic institutions, and communities.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-85_pg0ypo.jpg"
->
- 
-<p>The second issue is competing formats. Over the years people have proposed many different ways to implement structured data on the web. There's <a href="https://en.wikipedia.org/wiki/Resource_Description_Framework">RDF</a> and RDFa, <a href="https://en.wikipedia.org/wiki/JSON-LD">JSON-LD</a>, and <a href="https://en.wikipedia.org/wiki/Microformat">Microformats</a></p>
+  The original idea wasn't the problem, only the scale of it.
 
-Then there are all the annotation frameworks, query languages, and vocabularies that interact with these formats like [OWL](https://en.wikipedia.org/wiki/Web_Ontology_Language), [FOAF](<https://en.wikipedia.org/wiki/FOAF_(ontology)>), [SPARQL](https://en.wikipedia.org/wiki/SPARQL), [Turtle](<https://en.wikipedia.org/wiki/Turtle_(syntax)>), and more.
+  </div>
+  <div data-slide="16">
 
-You are probably overwhelmed by that list, and so are all the developers who are supposed to use them to make the dream of the semantic web come to life. It's not surprising most developers don't bother adding structured data to their sites.
+  Structured data is clearly useful. In fact, it's already actively used and useful across the web now. The most common use case you've likely heard of is around enabling SEO and "rich results" in search engines.
 
-</TalkSlide>
+  </div>
+  <div data-slide="17">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-86_nchcdq.jpg"
->
+  If I search for a recipe like "carrot cake" on the search engine Bing, I get a page filled with useful information like images, ratings, keywords, and Wikipedia data. All without needing to navigate to individual results pages. This is a much better experience than seeing a wall of text.
 
-Third, there are incentive issues. It takes a lot of developer labour to add semantic markup to a website, and doesn't offer immediate benefits in return. Structured data can certainly improve SEO and content discovery, but beyond that we haven't found enough compelling use cases for it.
+  Bing knows which sites contain carrot cake recipes and can surface details from those recipes because they contain structured data.
 
-</TalkSlide>
+  </div>
+  <div data-slide="18">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-14_b9eqty.jpg"
->
- 
-<p>Lastly, the ambitious scale of the semantic web compounds all the above problems. Trying to structure data across the <i>entire web</i> leads to issues of complexity.</p>
+  Similarly, if I search for the book "The Dawn of Everything" on Google, I get page showing me key information about the book. But I also get a row of options for where to buy this book and how much it costs.
 
-All these problems have made a lot of people skeptical about the feasibility of the semantic web. They're quite keen to throw the baby out with the bathwater.
+  Which means Google knows the difference between sites that are simply mentioning or reviewing this book, versus which ones are selling it as a product. This distinction is only possible because of structured data.
 
-</TalkSlide>
+  Search results are perhaps our best modern success story of leveraging structured data in user interfaces.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-15_nqgsgj.jpg">
+  </div>
+  <div data-slide="19">
 
-The debate about the semantic web has devolved into an unhelpful binary.
+  Second, structured data can help us manage content in a way that leads to adaptable, more sophisticated UX. This use case is what most of the people at this conference are focused on.
 
-On one side we have people insisting that structured data on the web has failed and will never work.
+  Structuring content just within a single company can lead to enormous benefits. Tools like [Sanity](https://www.sanity.io/) are one way to do this. It allows us to adapt and reuse content within many contexts.
 
-And on the other side we have people who are adamant that we need to fulfil the dream of a fully semantic web.
+  </div>
+  <div data-slide="20">
 
-This conversation doesn't leave a lot of room for nuance.
+  This is an example of a content model from the book [Designing Connected Content](https://learning.oreilly.com/library/view/designing-connected-content/9780134764061/). It shows a set of entities, properties, and relationships related to an Event type. This sort of structured content modelling allows us to create interfaces that provide users with a clear [mental model](https://www.nngroup.com/articles/mental-models/) of the things they're interacting with. It also makes it easy to define these pieces of data in one central place and flexibly reuse them across devices, platforms, and contexts.
 
-</TalkSlide>
+  </div>
+  <div data-slide="21">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-16_iaudhy.jpg">
+  Lastly, structured data makes life much easier for data scientists and academics. Data scientists in particular have trouble getting good quality data off the web. They often have to scrape websites, download messy data files, then manually clean, label, and format the data before they can work with it. Structured data eliminates much of that work.
 
-What's we're missing here is the sensible middle ground of opportunity. There's plenty of value in pursuing structured data at a smaller scale. It's much easier to agree upon and maintain ontologies within companies, sets of companies, academic institutions, and communities.
+  There's also a lot of interest from the academic community around "knowledge graphs", which are structured ontologies they use to share knowledge within specific domains.
 
-The original idea wasn't the problem, only the scale of it.
+  </div>
+<div data-slide="22">
 
-</TalkSlide>
+  Let's jump back to our structured data binary for a moment. Right now we're about here on the spectrum of no structured data to all structured data. A very small percentage of content on the web is encoded with structured data.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-17_rcmfnr.jpg">
+  We also don't have a lot of accessible, high-quality software that helps us create and publish more structured data.
 
-Structured data is clearly useful. In fact, it's already actively used and useful across the web now. The most common use case you've likely heard of is around enabling SEO and “rich results” in search engines.
+  </div>
+  <div data-slide="23">
 
-</TalkSlide>
+  I think a practical question we should all be asking is how do we get _here_? Rather than trying to make the _whole_ web structured data, how do we simply nudge this arrow slightly further along to the right?
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-18_uaojs7.jpg">
+  The goal is _more_ structured data, not _all_ structured data.
 
-If I search for a recipe like “carrot cake” on the search engine Bing, I get a page filled with useful information like images, ratings, keywords, and Wikipedia data. All without needing to navigate to individual results pages. This is a much better experience than seeing a wall of text.
+  </div>
+  <div data-slide="24">
 
-Bing knows which sites contain carrot cake recipes and can surface details from those recipes because they contain structured data.
+  One of the major barriers to this goal is that almost all our existing tools related to structured data are designed to serve developers.
 
-</TalkSlide>
+  Most of the focus of the semantic web movement has gone into creating syntax formats like RDF, OWL, and JSON-LD. There's also been a lot of effort put into convincing developers to join the cause. Rather than other people who are involved in making content on the web, like designers, product people, and content strategists.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-19_auycdd.jpg">
+  </div>
+  <div data-slide="25">
 
-Similarly, if I search for the book “The Dawn of Everything” on Google, I get page showing me key information about the book. But I also get a row of options for where to buy this book and how much it costs.
+  And _this_ is a really rough user interface to work in. And it's certainly not accessible to most people.
 
-Which means Google knows the difference between sites that are simply mentioning or reviewing this book, versus which ones are selling it as a product. This distinction is only possible because of structured data.
+  </div>
+  <div data-slide="26">
 
-Search results are perhaps our best modern success story of leveraging structured data in user interfaces.
+  Which brings us to a prescient question: how do we make it easier for everyone to create structured data?
 
-</TalkSlide>
+  </div>
+  <div data-slide="27">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-20_jlaudh.jpg">
+  Or put more specifically, what type of interfaces might enable non-developers to create structured data?
 
-Second, structured data can help us manage content in a way that leads to adaptable, more sophisticated UX. This use case is what most of the people at this conference are focused on.
+  </div>
+  <div data-slide="28">
 
-Structuring content just within a single company can lead to enormous benefits. Tools like [Sanity](https://www.sanity.io/) are one way to do this. It allows us to adapt and reuse content within many contexts.
+  So, I have a hypothesis for this question. And you can probably guess what it is... blocks!
 
-</TalkSlide>
+  </div>
+  <div data-slide="29">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-21_y19gvo.jpg">
+  I now want to talk to you about the huge surge in blocks and composable interfaces we've seen over the last five years.
 
-This is an example of a content model from the book [Designing Connected Content](https://learning.oreilly.com/library/view/designing-connected-content/9780134764061/). It shows a set of entities, properties, and relationships related to an Event type. This sort of structured content modelling allows us to create interfaces that provide users with a clear [mental model](https://www.nngroup.com/articles/mental-models/) of the things they're interacting with. It also makes it easy to define these pieces of data in one central place and flexibly reuse them across devices, platforms, and contexts.
+  But first, what exactly do I mean by a "_block_"?
 
-</TalkSlide>
+  Well, you have almost certainly seen and used a block.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-22_xs3qqw.jpg">
+  </div>
+  <div data-slide="30">
 
-Lastly, structured data makes life much easier for data scientists and academics. Data scientists in particular have trouble getting good quality data off the web. They often have to scrape websites, download messy data files, then manually clean, label, and format the data before they can work with it. Structured data eliminates much of that work.
+  Most of you will have encountered blocks in an app like [Notion](https://notion.so), which is arguably responsible for the huge popularity boom in blocks.
 
-There's also a lot of interest from the academic community around “knowledge graphs”, which are structured ontologies they use to share knowledge within specific domains.
+  This is what the interface looks like. You begin on a page, type the slash command, and a menu appears where you can select a block from a list of pre-made formats. Such as a header, bullet point list, or a table. You can then enter data into that block and change the state of it. You can drag and drop these blocks around to arrange them however you like, including in side-by-side columns.
 
-</TalkSlide>
+  You're essentially able to create very powerful layouts and formats with a very simple set of interface patterns.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-23_mk6zve.jpg">
+  </div>
+  <div data-slide="31">
 
-Let's jump back to our structured data binary for a moment. Right now we're about here on the spectrum of no structured data to all structured data. A very small percentage of content on the web is encoded with structured data.
+  To show another example, this is [Coda](https://coda.io) which is one of the more advanced block-based editors. You can see here they have quite a long list of block types to pick from.
 
-We also don't have a lot of accessible, high-quality software that helps us create and publish more structured data.
+  I can embed rich media like tweets, or query an external API like the Unsplash image library. All from within a friendly set of user interface components, and without writing any code.
 
-</TalkSlide>
+  This might not seem that impressive to you. We've become slightly jaded about these type of interfaces; WYSIWYG direct manipulation interfaces are taken for granted. But creating something like this would have been prohibitively complex just 5 years ago.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-24_aazqtv.jpg">
+  This is all _very_ difficult to do if you're working in native web languages like HTML, CSS, and JS. For people who don't know how to code, block-based interfaces allow them to author rich media documents and publish them to the web in a couple of clicks. They're a huge leap forward in democratising web publishing.
 
-I think a practical question we should all be asking is how do we get _here_? Rather than trying to make the _whole_ web structured data, how do we simply nudge this arrow slightly further along to the right?
+  </div>
+<div data-slide="32">
 
-The goal is _more_ structured data, not _all_ structured data.
+  The interface patterns in block-based editors have already become quite consistent and standardised. In most of them you can type `/` and get a dropdown list of block options.
 
-</TalkSlide>
+  </div>
+  <div data-slide="33">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-25_j8hzy2.jpg">
+  In some of the more complex ones, they present blocks in a sidebar or configuration panel. But generally everyone has converged on a standardised format for how these editors work. Which is great for users who don't have to relearn the patterns for every new app.
 
-One of the major barriers to this goal is that almost all our existing tools related to structured data are designed to serve developers.
+  </div>
+  <div data-slide="34">
 
-Most of the focus of the semantic web movement has gone into creating syntax formats like RDF, OWL, and JSON-LD. There's also been a lot of effort put into convincing developers to join the cause. Rather than other people who are involved in making content on the web, like designers, product people, and content strategists.
+  So now that we've seen a couple of examples of block-based interfaces, I want to give you a more concise definition of a "block"
 
-</TalkSlide>
+  I define it as a single unit of content...
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-26_b0j2kx.jpg">
+  </div>
+  <div data-slide="35">
 
-And _this_ is a really rough user interface to work in. And it's certainly not accessible to most people.
+  ...within a document or canvas...
 
-</TalkSlide>
+  </div>
+  <div data-slide="36">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-27_rh3ste.jpg">
+  ...that can be flexibly composed and rearranged...
 
-Which brings us to a prescient question: how do we make it easier for everyone to create structured data?
+  </div>
+<div data-slide="37">
 
-</TalkSlide>
+  ...and has a _type_ that determines how it displays data.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-28_m4jhd7.jpg">
+  So a table obviously lays data out in rows and columns...
 
-Or put more specifically, what type of interfaces might enable non-developers to create structured data?
+  </div>
+  <div data-slide="38">
 
-</TalkSlide>
+  ...while a kanban lays it out in a set of cards.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-29_cl95ex.jpg">
+  Another key feature of blocks is you can _change that type_ while the data inside the block stays the same. This means we have a separation of the data from the view. So a set of kanban cards could become...
 
-So, I have a hypothesis for this question. And you can probably guess what it is... blocks!
+  </div>
+  <div data-slide="39">
 
-</TalkSlide>
+  ...an image gallery.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-30_rjmqly.jpg">
+  </div>
+  <div data-slide="40">
 
-I now want to talk to you about the huge surge in blocks and composable interfaces we've seen over the last five years.
+  And critically, blocks allow _end-users_, meaning anyone who is _not_ a professional developer, to create, edit, and delete the data within these blocks. All without writing any code. The users are in control of the data rather than the developers.
 
-But first, what exactly do I mean by a “_block_”?
+  </div>
+  <div data-slide="41">
 
-Well, you have almost certainly seen and used a block.
+  Blocks also enable what I call _modular, composable interfaces_. Open canvases where users can drag and drop blocks into place like legos. These are easy to use and accessible to a much wider audience than any markup or syntax could hope to be.
 
-</TalkSlide>
+  </div>
+<div data-slide="42">
 
-<TalkSlide video imgSrc="https://res.cloudinary.com/dxj9qr5gj/video/upload/ac_none,q_auto:best/v1654118527/maggieappleton.com/notes/block-data/notion_dah06m.mp4">
+  These types of interfaces are obviously very **powerful** and **popular**. And to explain why I'm going to reference a quote from [Joel Spolsky](https://www.joelonsoftware.com/), who co-founded [HASH](https://hash.ai), as well as companies like [Stack Overflow](https://stackoverflow.com/), [Trello](https://trello.com/), and [Glitch](https://glitch.com/). (Apologies for quoting the founder of my own company. Clearly a bit of a faux pas, but he's obviously been thinking about these issues for a long time.)
 
-_This is a video - click play on the slide_
+  In his [announcement post](https://www.joelonsoftware.com/2012/01/06/how-trello-is-different/) for Trello, he said "The great horizontal killer applications are actually just fancy data structures."
 
-Most of you will have encountered blocks in an app like [Notion](https://notion.so), which is arguably responsible for the huge popularity boom in blocks.
+  By "horizontal" he means applications that have a wide range of uses cases. Things like spreadsheets and word processes. Apps you can use for everything from financial analysis to grocery shopping lists.
 
-This is what the interface looks like. You begin on a page, type the slash command, and a menu appears where you can select a block from a list of pre-made formats. Such as a header, bullet point list, or a table. You can then enter data into that block and change the state of it. You can drag and drop these blocks around to arrange them however you like, including in side-by-side columns.
+  The reason these apps are great for such a broad range of use cases is they give users really strong data structures to work within.
 
-You're essentially able to create very powerful layouts and formats with a very simple set of interface patterns.
+  </div>
+  <div data-slide="43">
 
-</TalkSlide>
+  And I think block-based apps are becoming the meta-medium for horizontal apps. They're a material with the potential to do whatever you need them to. They allow you to _pick your own_ fancy data structures from a wide list.
 
-<TalkSlide video imgSrc="https://res.cloudinary.com/dxj9qr5gj/video/upload/ac_none,q_auto:best/v1654118525/maggieappleton.com/notes/block-data/coda_rwocpi.mp4">
+  </div>
+  <div data-slide="44">
 
-_This is a video - click play on the slide_
+  Unsurprisingly, block-based apps have started popping up everywhere. There are three main categories they fall into.
 
-To show another example, this is [Coda](https://coda.io) which is one of the more advanced block-based editors. You can see here they have quite a long list of block types to pick from.
+  First is documents, wikis, and knowledge management systems. The kinds of apps people use for note-taking or team communications. This is the most popular use case at the moment.
 
-I can embed rich media like tweets, or query an external API like the Unsplash image library. All from within a friendly set of user interface components, and without writing any code.
+  </div>
+  <div data-slide="45">
 
-This might not seem that impressive to you. We've become slightly jaded about these type of interfaces; WYSIWYG direct manipulation interfaces are taken for granted. But creating something like this would have been prohibitively complex just 5 years ago.
+  Second is WYSIWYG website builders and web publishing platforms. This includes platforms like WordPress's Gutenberg editor, Squarespace, and Webflow. They're explicitly designed to help you create standard web designs like landing pages, contact forms, and blogs.
 
-This is all _very_ difficult to do if you're working in native web languages like HTML, CSS, and JS. For people who don't know how to code, block-based interfaces allow them to author rich media documents and publish them to the web in a couple of clicks. They're a huge leap forward in democratising web publishing.
+  </div>
+  <div data-slide="46">
 
-</TalkSlide>
+  The third category that's just starting to take shape is what I'm calling "Do-it-Yourself SaaS tooling." These apps give users to ability to create their own interfaces with a lot more programmatic functionality baked in. You can usually query a separate data source, add if this/then that logic to elements, and define more advanced block functionality like filterable lists and dropdown selectors.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-31_vwgy0a.jpg">
+  Rather than subscribing to 10 different SaaS services, these apps are beginning to let you build your own solutions.
 
-The interface patterns in block-based editors have already become quite consistent and standardised. In most of them you can type `/` and get a dropdown list of block options.
+  </div>
+  <div data-slide="47">
 
-</TalkSlide>
+  The lines between these categories are quite fuzzy. I think of it as a spectrum of block-based paradigms. Each app frames what you're creating slightly differently. Some present it as a document, some as a website, and some as a fully-fledged app.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-32_gpzcay.jpg">
+  But they're all following the same interface patterns to do it. The difference between these block-based editors become window dressing when you begin to look closely at what they actually make possible.
 
-In some of the more complex ones, they present blocks in a sidebar or configuration panel. But generally everyone has converged on a standardised format for how these editors work. Which is great for users who don't have to relearn the patterns for every new app.
+  Which is why so many people end up using Notion as a website builder, despite the fact Notion never expected that to happen.
 
-</TalkSlide>
+  </div>
+<div data-slide="48">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-33_xgfffh.jpg">
+  But I think the _real_ benefit of these block-based applications – the reason they're so widely used – is they **shift power from developers to users**.
 
-So now that we've seen a couple of examples of block-based interfaces, I want to give you a more concise definition of a “block”
+  They give users agency over what the app can do. Users are given a set of tools with enough flexibility to solve their own problems. Rather than developers, designers, and product managers imagining hypothetical problems for the user, and then imposing their ideas of how an app 'should' work to solve those problems.
 
-I define it as a single unit of content...
+  Obviously, block-based interface do not _fully_ hand over control to the user. But they enable more [end-user programming](https://en.wikipedia.org/wiki/End-user_development) to take place. And they're doing it in a way that was frankly impossible just 5 years ago.
 
-</TalkSlide>
+  If 5 years ago I wanted to put a table of data onto a website, I would be writing the HTML, CSS, and JS for that myself. And it would definitely not be as good as the table Coda or Notion give me. And now I can do it in two clicks.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-34_rcbzi2.jpg">
+  </div>
+  <div data-slide="49">
 
-...within a document or canvas...
+  We've established that blocks are wildly popular, and they enable hundreds of thousands of people to publish rich, complex documents to the web.
 
-</TalkSlide>
+  So, what's the problem here? And how does this relate to structured data?
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-35_anqzil.jpg">
+  </div>
+  <div data-slide="50">
 
-...that can be flexibly composed and rearranged...
+  First, blocks are proprietary to individual applications, and can't be moved between applications.
 
-</TalkSlide>
+  </div>
+  <div data-slide="51">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-36_zmgcoy.jpg">
+  If I have a block that I love using in one of my apps – probably because it's well designed and easy to interace with – I'm only able to use it within that app.
 
-...and has a _type_ that determines how it displays data.
+  Let's say there's a block that renders LaTeX beautifully in my note-taking app. But I also want to publish LaTeX code to my website and my company wiki. But those apps don't have blocks that render LaTeX. I'm now stuck. There's no way for me to port the LaTeX block across applications.
 
-So a table obviously lays data out in rows and columns...
+  </div>
+  <div data-slide="52">
 
-</TalkSlide>
+  Closely related to that: an _enourmous_ number of developer hours are spent reinventing the same blocks over and over.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-37_gutn96.jpg">
+  Most of these apps have the same basic types of blocks; header, checklist, table, image, embed, etc. But every team of developers has to build their own set of these.
 
-...while a kanban lays it out in a set of cards.
+  </div>
+  <div data-slide="53">
 
-Another key feature of blocks is you can _change that type_ while the data inside the block stays the same. This means we have a separation of the data from the view. So a set of kanban cards could become...
+  If we look at the kanban block in Notion, Coda, and ClickUp, we'll notice they all work the same. They offer the same basic functionality, format, and interactions. But the developers had to build each of these seperately.
 
-</TalkSlide>
+  Anyone building a new block-based app will have to build their own kanban, even though this is a solved problem.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-38_iwgjur.jpg">
+  This is a waste of time and energy for developers. It's also frustrating for users, who have to learn slightly different interface patterns for each application. Even when their blocks all do the same thing in the end.
 
-...an image gallery.
+  </div>
+<div data-slide="54">
 
-</TalkSlide>
+  The next issue is that users only get access to a limited range of blocks.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-39_qlhmtc.jpg">
+  </div>
+  <div data-slide="55">
 
-And critically, blocks allow _end-users_, meaning anyone who is _not_ a professional developer, to create, edit, and delete the data within these blocks. All without writing any code. The users are in control of the data rather than the developers.
+  Users are given between 30-70 blocks in each of these applications, and usually on the lower end of that range.
 
-</TalkSlide>
+  Here's the block picker dropdown in an app [Clover](https://cloverapp.com/) with a fairly typical list of options.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-40_i731dr.png">
+  </div>
+  <div data-slide="56">
 
-Blocks also enable what I call _modular, composable interfaces_. Open canvases where users can drag and drop blocks into place like legos. These are easy to use and accessible to a much wider audience than any markup or syntax could hope to be.
+  Compare this to what your everyday React developer has access to. If I hop onto npm and search for "react components" I get over 64,000 results to pick from. Obviously, not all of these components are going to be block-like things. Many will be utilities or helpers.
 
-</TalkSlide>
+  But this still shows there is an _enourmous_ discrepancy between the power and choice developers have when constructing an interface compared to users.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-41_ee5eyc.jpg">
+  </div>
+  <div data-slide="57">
 
-These types of interfaces are obviously very **powerful** and **popular**. And to explain why I'm going to reference a quote from [Joel Spolsky](https://www.joelonsoftware.com/), who co-founded [HASH](https://hash.ai), as well as companies like [Stack Overflow](https://stackoverflow.com/), [Trello](https://trello.com/), and [Glitch](https://glitch.com/). (Apologies for quoting the founder of my own company. Clearly a bit of a faux pas, but he's obviously been thinking about these issues for a long time.)
+  The final and biggest problem with proprietary blocks is that there's no structured data behind these blocks. Which in turns leads to poor data interoperability between platforms.
 
-In his [announcement post](https://www.joelonsoftware.com/2012/01/06/how-trello-is-different/) for Trello, he said "The great horizontal killer applications are actually just fancy data structures."
+  </div>
+  <div data-slide="58">
 
-By "horizontal" he means applications that have a wide range of uses cases. Things like spreadsheets and word processes. Apps you can use for everything from financial analysis to grocery shopping lists.
+  A table in Wordpress Gutenberg and a table in Notion appear to have the same data structure on the surface. They both have values stored in rows are columns. But they're built differently on the back-end. They're not _designed_ to be shareable. Which means we can't easily pass data from a Gutenberg table into a Notion table.
 
-The reason these apps are great for such a broad range of use cases is they give users really strong data structures to work within.
+  </div>
+<div data-slide="59">
 
-</TalkSlide>
+  Which brings me to our last section: The Block Protocol!
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-42_hqkc7z.jpg">
+  The [Block Protocol](https://blockprotocol.org) is a project by [HASH](https://hash.ai) that hopes to address some of these problems.
 
-And I think block-based apps are becoming the meta-medium for horizontal apps. They're a material with the potential to do whatever you need them to. They allow you to _pick your own_ fancy data structures from a wide list.
+  </div>
+  <div data-slide="60">
 
-</TalkSlide>
+  It's a standardised way for any block to communicate with any block-based application
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-44_lmlej2.jpg">
+  </div>
+  <div data-slide="61">
 
-Unsurprisingly, block-based apps have started popping up everywhere. There are three main categories they fall into.
+  But rather than these two systems talking directly to one another, they instead both talk to the protocol. It's like a medium that negotiates between the two parties. A bit like a set of rules about what you can say and how you should say it.
 
-First is documents, wikis, and knowledge management systems. The kinds of apps people use for note-taking or team communications. This is the most popular use case at the moment.
+  Any block that talks to this protocol can talk to any application that talks to it, and vice versa.
 
-</TalkSlide>
+  </div>
+  <div data-slide="62">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-45_ufwbj5.jpg">
+  This makes it possible to embed blocks that follow the protocol into any app that also follows the protocol.
 
-Second is WYSIWYG website builders and web publishing platforms. This includes platforms like WordPress's Gutenberg editor, Squarespace, and Webflow. They're explicitly designed to help you create standard web designs like landing pages, contact forms, and blogs.
+  The developers of the block and the application don't have to know anything about one another, or co-ordinate their efforts. But they can make their software compatible through the protocol.
 
-</TalkSlide>
+  </div>
+  <div data-slide="63">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-46_mapaxa.jpg">
+  Embedding is great, but what we really want here is _data exchange_.
 
-The third category that's just starting to take shape is what I'm calling “Do-it-Yourself SaaS tooling.” These apps give users to ability to create their own interfaces with a lot more programmatic functionality baked in. You can usually query a separate data source, add if this/then that logic to elements, and define more advanced block functionality like filterable lists and dropdown selectors.
+  Our app has a data store that it controls. And our block wants to create new data. Let's say we've made a table block and typed some information into it.
 
-Rather than subscribing to 10 different SaaS services, these apps are beginning to let you build your own solutions.
+  Using the protocol, our block can send that data to the app's data store. It can then do all the standard operations you would expect. It can create new data, update existing data, delete data, and read data from the app.
 
-</TalkSlide>
+  Obviously, the block can only make these changes with the _permission_ of the app. There are certainly security implications here we're anicipating and building accomodations for.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-47_vceg1j.jpg">
+  </div>
+  <div data-slide="64">
 
-The lines between these categories are quite fuzzy. I think of it as a spectrum of block-based paradigms. Each app frames what you're creating slightly differently. Some present it as a document, some as a website, and some as a fully-fledged app.
+  Blocks can also send data to one another, which leads to some dynamic interactivity between them.
 
-But they're all following the same interface patterns to do it. The difference between these block-based editors become window dressing when you begin to look closely at what they actually make possible.
+  I like to think of these as [oEmbeds](https://en.wikipedia.org/wiki/OEmbed) or [iframes](https://en.wikipedia.org/wiki/HTML_element#Frames) with CRUD operations built-in.
 
-Which is why so many people end up using Notion as a website builder, despite the fact Notion never expected that to happen.
+  </div>
+<div data-slide="65">
 
-</TalkSlide>
+  Well, **so what?**
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-48_djteby.jpg">
+  Why do we care that all this embedding, data exchange, and interactivity is possible?
 
-But I think the _real_ benefit of these block-based applications – the reason they're so widely used – is they **shift power from developers to users**.
+  First of all, it means that any independent developer can build a block. Then anyone else can put that block into their application. And _it'll work_ without requiring extra dev work. As long as they both use the protocol.
 
-They give users agency over what the app can do. Users are given a set of tools with enough flexibility to solve their own problems. Rather than developers, designers, and product managers imagining hypothetical problems for the user, and then imposing their ideas of how an app 'should' work to solve those problems.
+  </div>
+  <div data-slide="66">
 
-Obviously, block-based interface do not _fully_ hand over control to the user. But they enable more [end-user programming](https://en.wikipedia.org/wiki/End-user_development) to take place. And they're doing it in a way that was frankly impossible just 5 years ago.
+  But really, **so what?** What does this mean in terms of practical user benefits?
 
-If 5 years ago I wanted to put a table of data onto a website, I would be writing the HTML, CSS, and JS for that myself. And it would definitely not be as good as the table Coda or Notion give me. And now I can do it in two clicks.
+  Well, in this hopeful world, users would be able to pick from a much wider variety of blocks.
 
-</TalkSlide>
+  </div>
+  <div data-slide="67">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-49_povv3i.jpg">
+  At the moment users get this limited list of 30 or so basic blocks.
 
-We've established that blocks are wildly popular, and they enable hundreds of thousands of people to publish rich, complex documents to the web.
+  </div>
+  <div data-slide="68">
 
-So, what's the problem here? And how does this relate to structured data?
+  But we would love to make it possible for users to have hundreds or thousands of specialised blocks to pick from. They should have a much wider variety of types available in their apps. People be able to pick from weirder, niche blocks like recipe creators, data visualisation displays, flight path trackers, or financial planners.
 
-</TalkSlide>
+  </div>
+  <div data-slide="69">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-50_wgxc0k.jpg">
+  Secondly, applications would get access to this wider range of blocks for little or no extra developer work.
 
-First, blocks are proprietary to individual applications, and can't be moved between applications.
+  </div>
+  <div data-slide="70">
 
-</TalkSlide>
+  Each app would be able to make this infinite list of block options available. Which saves the developers building those apps from having to make all these block types themselves, or rebuild a table block for the 100th time.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-51_kmfrfo.jpg">
+  It also offers their end-users a much better experience. Which is the whole point of their company.
 
-If I have a block that I love using in one of my apps – probably because it's well designed and easy to interace with – I'm only able to use it within that app.
+  </div>
+<div data-slide="71">
 
-Let's say there's a block that renders LaTeX beautifully in my note-taking app. But I also want to publish LaTeX code to my website and my company wiki. But those apps don't have blocks that render LaTeX. I'm now stuck. There's no way for me to port the LaTeX block across applications.
+  Lastly, this protocol makes it easier to create structured data and encourages more data interopability.
 
-</TalkSlide>
+  </div>
+  <div data-slide="72">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-52_df4uha.jpg">
+  Blocks that follow the protocol must declare a schema – an expected data structure.
 
-Closely related to that: an _enourmous_ number of developer hours are spent reinventing the same blocks over and over.
+  So a to-do list block would expect to reviece a set of `Task` items
 
-Most of these apps have the same basic types of blocks; header, checklist, table, image, embed, etc. But every team of developers has to build their own set of these.
+  </div>
+  <div data-slide="73">
 
-</TalkSlide>
+  And that `Task` will have an expected list of properties like a `title`, `description`, `status`, and `dueDate`. We declare these in a JSON object and valiadate them with [JSON schema](https://json-schema.org/).
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-53_q0cxdl.jpg">
+  </div>
+  <div data-slide="74">
 
-If we look at the kanban block in Notion, Coda, and ClickUp, we'll notice they all work the same. They offer the same basic functionality, format, and interactions. But the developers had to build each of these seperately.
+  This means that blocks can be designed to fit specific data structures, rather than all being generic formats.
 
-Anyone building a new block-based app will have to build their own kanban, even though this is a solved problem.
+  We could have very specialised block types like a Flight Map block that takes in a `Flight` data structure, or a Movie Review block that takes in a `Movie` data structure.
 
-This is a waste of time and energy for developers. It's also frustrating for users, who have to learn slightly different interface patterns for each application. Even when their blocks all do the same thing in the end.
+  </div>
+  <div data-slide="75">
 
-</TalkSlide>
+  This gives us an interesting new interplay of data and views. We can start with structured data – with specific concepts – and then find a block that's specifically designed to display it.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-54_pfeg1o.jpg">
+  </div>
+  <div data-slide="76">
 
-The next issue is that users only get access to a limited range of blocks.
+  The power of this can best be explained by a quote from the late, great Christopher Alexander: "Design is finding a form to fit a context"
 
-</TalkSlide>
+  Structured data is a kind of context, and blocks give us the flexibility to find the right form for it.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-55_r98d9x.jpg">
+  </div>
+  <div data-slide="77">
 
-Users are given between 30-70 blocks in each of these applications, and usually on the lower end of that range.
+  There's also another layer to this. We can go the other direction and use blocks to _create_ structured data.
 
-Here's the block picker dropdown in an app [Clover](https://cloverapp.com/) with a fairly typical list of options.
+  We can start with a block which has a user-friendly interface to input and edit data. And once we've typed values into it, the block can create the structured data for us, because it already has a schema defined. And this is all a much better user experience than writing JDON-LD or RDF code syntax.
 
-</TalkSlide>
+  </div>
+<div data-slide="78">
 
-<TalkSlide imgSrc="/images/posts/block-data/react_component_-_npm_search_fg9sue.png">
+  So this is all a lovely idea, but I'm sure many of you are already thinking of all the horrendous ways this could go wrong.
 
-Compare this to what your everyday React developer has access to. If I hop onto npm and search for “react components” I get over 64,000 results to pick from. Obviously, not all of these components are going to be block-like things. Many will be utilities or helpers.
+  There are plenty of challenges and problems with trying to build this protocol, and we're actively working on them in public. The current [specification](https://blockprotocol.org/spec) of the protocol is an early alpha draft that we're looking for feedback on.
 
-But this still shows there is an _enourmous_ discrepancy between the power and choice developers have when constructing an interface compared to users.
+  A few of the major challenges we have draft solutions for are security and sandboxing for untusted blocks, maintaining consistent UX and styling across blocks, and handling schema divergence.
 
-</TalkSlide>
+  </div>
+  <div data-slide="79">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-57_cgr1cm.jpg">
+  There's many more of these. We have an [FAQ](https://blockprotocol.org/faq) page with extensive answers written for each of these. We're always looking to add more so feel free to [get in touch](https://blockprotocol.org/contact) if your question isn't answered.
 
-The final and biggest problem with proprietary blocks is that there's no structured data behind these blocks. Which in turns leads to poor data interoperability between platforms.
+  </div>
+  <div data-slide="80">
 
-</TalkSlide>
+  The bigger picture goal of this whole project is to create a virtous cycle. We want people to create blocks, so that blocks can create structured data, so that people have access to more structured data to reuse in blocks.
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-58_agaokt.jpg">
+  </div>
+  <div data-slide="81">
 
-A table in Wordpress Gutenberg and a table in Notion appear to have the same data structure on the surface. They both have values stored in rows are columns. But they're built differently on the back-end. They're not _designed_ to be shareable. Which means we can't easily pass data from a Gutenberg table into a Notion table.
+  In turn, we hope this leads to better user experiences, better data science, and eventually better decision-making tools.
 
-</TalkSlide>
+  </div>
+  <div data-slide="82">
 
-<TalkSlide imgSrc="/images/posts/block-data/block-data-59_hq22zu.jpg">
+  That's all I have! Thank you for reading.
 
-Which brings me to our last section: The Block Protocol!
-
-The [Block Protocol](https://blockprotocol.org) is a project by [HASH](https://hash.ai) that hopes to address some of these problems.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-60_tnuksm.jpg">
-
-It's a standardised way for any block to communicate with any block-based application
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-61_ezuhhs.jpg">
-
-But rather than these two systems talking directly to one another, they instead both talk to the protocol. It's like a medium that negotiates between the two parties. A bit like a set of rules about what you can say and how you should say it.
-
-Any block that talks to this protocol can talk to any application that talks to it, and vice versa.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-62_xnoncm.jpg">
-
-This makes it possible to embed blocks that follow the protocol into any app that also follows the protocol.
-
-The developers of the block and the application don't have to know anything about one another, or co-ordinate their efforts. But they can make their software compatible through the protocol.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data.001_x4vw74.jpg">
-
-Embedding is great, but what we really want here is _data exchange_.
-
-Our app has a data store that it controls. And our block wants to create new data. Let's say we've made a table block and typed some information into it.
-
-Using the protocol, our block can send that data to the app's data store. It can then do all the standard operations you would expect. It can create new data, update existing data, delete data, and read data from the app.
-
-Obviously, the block can only make these changes with the _permission_ of the app. There are certainly security implications here we're anicipating and building accomodations for.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data.002_nalvgm.jpg">
-
-Blocks can also send data to one another, which leads to some dynamic interactivity between them.
-
-I like to think of these as [oEmbeds](https://en.wikipedia.org/wiki/OEmbed) or [iframes](https://en.wikipedia.org/wiki/HTML_element#Frames) with CRUD operations built-in.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-66_nn0ctp.jpg">
-
-Well, **so what?**
-
-Why do we care that all this embedding, data exchange, and interactivity is possible?
-
-First of all, it means that any independent developer can build a block. Then anyone else can put that block into their application. And _it'll work_ without requiring extra dev work. As long as they both use the protocol.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-67_lecmbn.jpg">
-
-But really, **so what?** What does this mean in terms of practical user benefits?
-
-Well, in this hopeful world, users would be able to pick from a much wider variety of blocks.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-68_c3qm9o.jpg">
-
-At the moment users get this limited list of 30 or so basic blocks.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-69_evpdsa.jpg">
-
-But we would love to make it possible for users to have hundreds or thousands of specialised blocks to pick from. They should have a much wider variety of types available in their apps. People be able to pick from weirder, niche blocks like recipe creators, data visualisation displays, flight path trackers, or financial planners.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-70_svbws9.jpg">
-
-Secondly, applications would get access to this wider range of blocks for little or no extra developer work.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-71_sqoqil.jpg">
-
-Each app would be able to make this infinite list of block options available. Which saves the developers building those apps from having to make all these block types themselves, or rebuild a table block for the 100th time.
-
-It also offers their end-users a much better experience. Which is the whole point of their company.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-72_ddmtbq.jpg">
-
-Lastly, this protocol makes it easier to create structured data and encourages more data interopability.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-73_rvfepe.jpg">
-
-Blocks that follow the protocol must declare a schema – an expected data structure.
-
-So a to-do list block would expect to reviece a set of `Task` items
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-74_gbsnzv.jpg">
-
-And that `Task` will have an expected list of properties like a `title`, `description`, `status`, and `dueDate`. We declare these in a JSON object and valiadate them with [JSON schema](https://json-schema.org/).
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-75_yz2dsb.jpg">
-
-This means that blocks can be designed to fit specific data structures, rather than all being generic formats.
-
-We could have very specialised block types like a Flight Map block that takes in a `Flight` data structure, or a Movie Review block that takes in a `Movie` data structure.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-76_qeyxil.jpg">
-
-This gives us an interesting new interplay of data and views. We can start with structured data – with specific concepts – and then find a block that's specifically designed to display it.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-77_z3mzp3.jpg">
-
-The power of this can best be explained by a quote from the late, great Christopher Alexander: “Design is finding a form to fit a context”
-
-Structured data is a kind of context, and blocks give us the flexibility to find the right form for it.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-78_slbtws.jpg">
-
-There's also another layer to this. We can go the other direction and use blocks to _create_ structured data.
-
-We can start with a block which has a user-friendly interface to input and edit data. And once we've typed values into it, the block can create the structured data for us, because it already has a schema defined. And this is all a much better user experience than writing JDON-LD or RDF code syntax.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-79_zi4f24.jpg">
-
-So this is all a lovely idea, but I'm sure many of you are already thinking of all the horrendous ways this could go wrong.
-
-There are plenty of challenges and problems with trying to build this protocol, and we're actively working on them in public. The current [specification](https://blockprotocol.org/spec) of the protocol is an early alpha draft that we're looking for feedback on.
-
-A few of the major challenges we have draft solutions for are security and sandboxing for untusted blocks, maintaining consistent UX and styling across blocks, and handling schema divergence.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-80_shsciy.jpg">
-
-There's many more of these. We have an [FAQ](https://blockprotocol.org/faq) page with extensive answers written for each of these. We're always looking to add more so feel free to [get in touch](https://blockprotocol.org/contact) if your question isn't answered.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-81_wzdywu.jpg">
-
-The bigger picture goal of this whole project is to create a virtous cycle. We want people to create blocks, so that blocks can create structured data, so that people have access to more structured data to reuse in blocks.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-82_amfyan.jpg">
-
-In turn, we hope this leads to better user experiences, better data science, and eventually better decision-making tools.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/block-data/block-data-83_hj9yb9.jpg">
-
-That's all I have! Thank you for reading.
-
-</TalkSlide>
+  </div>
+</ScrollyTalkSection>


### PR DESCRIPTION
## Summary
- New `ScrollyTalkSection` component: sticky slide images on the left with scrollama-triggered transitions, scrolling text on the right (60/40 split)
- Responsive mobile layout using CSS flexbox ordering (no JS DOM manipulation)
- Consolidated block-data talk from 12 separate scrolly sections into one continuous 83-slide flow
- Dynamic mobile CSS generation supports arbitrary slide counts

## Test plan
- [x] Verify desktop scrollytelling works (slides transition as text scrolls)
- [x] Verify mobile layout (image-text pairs interleaved correctly)
- [x] Test resize between desktop and mobile breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)