### PR TITLE
Fix View Transitions lifecycle bugs in 5 components

### DIFF
--- a/src/components/layouts/TableOfContents.astro
+++ b/src/components/layouts/TableOfContents.astro
@@ -212,7 +212,32 @@ const { headings } = Astro.props;
 </style>
 
 <script>
+	let scrollTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+	function cleanupTOC() {
+		clearTimeout(scrollTimeoutId);
+
+		const tocHeader = document.getElementById("desktop-toc-header");
+		const existingHandlers = (tocHeader as any)?._tocHandlers;
+		if (existingHandlers) {
+			tocHeader?.removeEventListener("click", existingHandlers.desktopClick);
+			const header = document.querySelector(".collapse-header");
+			header?.removeEventListener("click", existingHandlers.mobileClick);
+			window.removeEventListener("scroll", existingHandlers.scroll);
+		}
+
+		document.querySelectorAll(".toc-link").forEach((link) => {
+			const handler = (link as any)._tocLinkHandler;
+			if (handler) {
+				link.removeEventListener("click", handler);
+			}
+		});
+	}
+
 	function initializeTOC() {
+		// Clean up before re-initializing
+		cleanupTOC();
+
 		let isCollapsed = false;
 		let isAutoCollapsed = false;
 		let isScrollingToSection = false;
@@ -234,22 +259,6 @@ const { headings } = Astro.props;
 		const header = document.querySelector(".collapse-header");
 		const content = document.querySelector(".collapse-content");
 		const mobileArrow = header?.querySelector(".arrow-icon");
-
-		// Clean up existing listeners if they exist
-		const existingHandlers = (tocHeader as any)?._tocHandlers;
-		if (existingHandlers) {
-			tocHeader?.removeEventListener("click", existingHandlers.desktopClick);
-			header?.removeEventListener("click", existingHandlers.mobileClick);
-			window.removeEventListener("scroll", existingHandlers.scroll);
-			
-			// Remove TOC link listeners
-			document.querySelectorAll(".toc-link").forEach((link, index) => {
-				const handler = (link as any)._tocLinkHandler;
-				if (handler) {
-					link.removeEventListener("click", handler);
-				}
-			});
-		}
 
 		// Desktop toggle handler
 		const desktopClickHandler = () => {
@@ -320,7 +329,8 @@ const { headings } = Astro.props;
 				});
 
 				// Re-enable scrolling flag after smooth scroll completes
-				setTimeout(() => {
+				clearTimeout(scrollTimeoutId);
+				scrollTimeoutId = setTimeout(() => {
 					isScrollingToSection = false;
 				}, 1000);
 
@@ -338,9 +348,9 @@ const { headings } = Astro.props;
 
 	// Re-initialize after view transitions with a small delay to ensure DOM is ready
 	document.addEventListener("astro:page-load", () => {
-		// Use requestAnimationFrame to ensure layout has been painted
 		requestAnimationFrame(() => {
 			initializeTOC();
 		});
 	});
+	document.addEventListener("astro:before-swap", cleanupTOC);
 </script>

--- a/src/components/layouts/TableOfContents.astro
+++ b/src/components/layouts/TableOfContents.astro
@@ -212,32 +212,10 @@ const { headings } = Astro.props;
 </style>
 
 <script>
-	let scrollTimeoutId: ReturnType<typeof setTimeout> | undefined;
+	import { onPageLifecycle } from "../../utils/viewTransitionLifecycle";
 
-	function cleanupTOC() {
-		clearTimeout(scrollTimeoutId);
-
-		const tocHeader = document.getElementById("desktop-toc-header");
-		const existingHandlers = (tocHeader as any)?._tocHandlers;
-		if (existingHandlers) {
-			tocHeader?.removeEventListener("click", existingHandlers.desktopClick);
-			const header = document.querySelector(".collapse-header");
-			header?.removeEventListener("click", existingHandlers.mobileClick);
-			window.removeEventListener("scroll", existingHandlers.scroll);
-		}
-
-		document.querySelectorAll(".toc-link").forEach((link) => {
-			const handler = (link as any)._tocLinkHandler;
-			if (handler) {
-				link.removeEventListener("click", handler);
-			}
-		});
-	}
-
-	function initializeTOC() {
-		// Clean up before re-initializing
-		cleanupTOC();
-
+	onPageLifecycle(() => {
+		let scrollTimeoutId: ReturnType<typeof setTimeout> | undefined;
 		let isCollapsed = false;
 		let isAutoCollapsed = false;
 		let isScrollingToSection = false;
@@ -264,7 +242,7 @@ const { headings } = Astro.props;
 		const desktopClickHandler = () => {
 			isCollapsed = !isCollapsed;
 			isAutoCollapsed = false;
-			disableAutoCollapse = false; // Re-enable auto-collapse when user manually toggles
+			disableAutoCollapse = false;
 			desktopContainer?.classList.toggle("collapsed", isCollapsed);
 			arrowIcon?.classList.toggle("collapsed", isCollapsed);
 		};
@@ -295,21 +273,13 @@ const { headings } = Astro.props;
 			}
 		};
 
-		// Store handlers for cleanup
-		if (tocHeader) {
-			(tocHeader as any)._tocHandlers = {
-				desktopClick: desktopClickHandler,
-				mobileClick: mobileClickHandler,
-				scroll: scrollHandler
-			};
-		}
-
 		// Add event listeners
 		tocHeader?.addEventListener("click", desktopClickHandler);
 		header?.addEventListener("click", mobileClickHandler);
 		window.addEventListener("scroll", scrollHandler);
 
 		// Smooth scrolling for TOC links
+		const linkHandlers: Array<{ link: Element; handler: EventListener }> = [];
 		document.querySelectorAll(".toc-link").forEach((link) => {
 			const linkClickHandler = (e: Event) => {
 				e.preventDefault();
@@ -321,14 +291,13 @@ const { headings } = Astro.props;
 				if (!targetElement) return;
 
 				isScrollingToSection = true;
-				disableAutoCollapse = true; // Disable auto-collapse after clicking TOC link
+				disableAutoCollapse = true;
 
 				targetElement.scrollIntoView({
 					behavior: "smooth",
 					block: "start",
 				});
 
-				// Re-enable scrolling flag after smooth scroll completes
 				clearTimeout(scrollTimeoutId);
 				scrollTimeoutId = setTimeout(() => {
 					isScrollingToSection = false;
@@ -337,20 +306,18 @@ const { headings } = Astro.props;
 				history.pushState(null, "", `#${targetId}`);
 			};
 
-			// Store handler for cleanup
-			(link as any)._tocLinkHandler = linkClickHandler;
+			linkHandlers.push({ link, handler: linkClickHandler });
 			link.addEventListener("click", linkClickHandler);
 		});
-	}
 
-	// Initialize on page load
-	initializeTOC();
-
-	// Re-initialize after view transitions with a small delay to ensure DOM is ready
-	document.addEventListener("astro:page-load", () => {
-		requestAnimationFrame(() => {
-			initializeTOC();
-		});
+		return () => {
+			clearTimeout(scrollTimeoutId);
+			tocHeader?.removeEventListener("click", desktopClickHandler);
+			header?.removeEventListener("click", mobileClickHandler);
+			window.removeEventListener("scroll", scrollHandler);
+			linkHandlers.forEach(({ link, handler }) => {
+				link.removeEventListener("click", handler);
+			});
+		};
 	});
-	document.addEventListener("astro:before-swap", cleanupTOC);
 </script>

--- a/src/components/layouts/VersionDropdown.astro
+++ b/src/components/layouts/VersionDropdown.astro
@@ -317,18 +317,9 @@ const getVersionUrl = (version: VersionedContent) => {
 </style>
 
 <script>
-	let currentDropdownState: {
-		outsideClickHandler: EventListener;
-		outsideFocusHandler: EventListener;
-		triggerClickHandler: EventListener;
-		triggerKeydownHandler: EventListener;
-		menuKeydownHandler: EventListener;
-	} | null = null;
+	import { onPageLifecycle } from "../../utils/viewTransitionLifecycle";
 
-	function initVersionDropdown() {
-		// Clean up previous listeners first
-		cleanupVersionDropdown();
-
+	onPageLifecycle(() => {
 		const dropdown = document.querySelector(".version-dropdown");
 		const trigger = dropdown?.querySelector(".version-trigger") as HTMLElement | null;
 		const menu = dropdown?.querySelector(".version-menu") as HTMLElement | null;
@@ -449,32 +440,12 @@ const getVersionUrl = (version: VersionedContent) => {
 		document.addEventListener("click", outsideClickHandler);
 		document.addEventListener("focusin", outsideFocusHandler);
 
-		currentDropdownState = {
-			outsideClickHandler,
-			outsideFocusHandler,
-			triggerClickHandler,
-			triggerKeydownHandler,
-			menuKeydownHandler,
+		return () => {
+			trigger.removeEventListener("click", triggerClickHandler);
+			trigger.removeEventListener("keydown", triggerKeydownHandler);
+			menu.removeEventListener("keydown", menuKeydownHandler);
+			document.removeEventListener("click", outsideClickHandler);
+			document.removeEventListener("focusin", outsideFocusHandler);
 		};
-	}
-
-	function cleanupVersionDropdown() {
-		if (!currentDropdownState) return;
-		const { outsideClickHandler, outsideFocusHandler, triggerClickHandler, triggerKeydownHandler, menuKeydownHandler } = currentDropdownState;
-
-		const trigger = document.querySelector(".version-dropdown .version-trigger");
-		const menu = document.querySelector(".version-dropdown .version-menu");
-
-		trigger?.removeEventListener("click", triggerClickHandler);
-		trigger?.removeEventListener("keydown", triggerKeydownHandler);
-		menu?.removeEventListener("keydown", menuKeydownHandler);
-		document.removeEventListener("click", outsideClickHandler);
-		document.removeEventListener("focusin", outsideFocusHandler);
-
-		currentDropdownState = null;
-	}
-
-	initVersionDropdown();
-	document.addEventListener("astro:page-load", initVersionDropdown);
-	document.addEventListener("astro:before-swap", cleanupVersionDropdown);
+	});
 </script>

--- a/src/components/layouts/VersionDropdown.astro
+++ b/src/components/layouts/VersionDropdown.astro
@@ -317,10 +317,21 @@ const getVersionUrl = (version: VersionedContent) => {
 </style>
 
 <script>
-	document.addEventListener("DOMContentLoaded", function () {
+	let currentDropdownState: {
+		outsideClickHandler: EventListener;
+		outsideFocusHandler: EventListener;
+		triggerClickHandler: EventListener;
+		triggerKeydownHandler: EventListener;
+		menuKeydownHandler: EventListener;
+	} | null = null;
+
+	function initVersionDropdown() {
+		// Clean up previous listeners first
+		cleanupVersionDropdown();
+
 		const dropdown = document.querySelector(".version-dropdown");
-		const trigger = dropdown?.querySelector(".version-trigger");
-		const menu = dropdown?.querySelector(".version-menu");
+		const trigger = dropdown?.querySelector(".version-trigger") as HTMLElement | null;
+		const menu = dropdown?.querySelector(".version-menu") as HTMLElement | null;
 		const options = dropdown?.querySelectorAll('[role="option"]');
 
 		if (!dropdown || !trigger || !menu) return;
@@ -331,20 +342,19 @@ const getVersionUrl = (version: VersionedContent) => {
 
 		function openDropdown() {
 			isOpen = true;
-			menu.classList.add("open");
-			trigger.setAttribute("aria-expanded", "true");
+			menu!.classList.add("open");
+			trigger!.setAttribute("aria-expanded", "true");
 		}
 
 		function closeDropdown() {
 			isOpen = false;
-			menu.classList.remove("open");
-			trigger.setAttribute("aria-expanded", "false");
+			menu!.classList.remove("open");
+			trigger!.setAttribute("aria-expanded", "false");
 			currentIndex = -1;
-			// Return focus to trigger
-			trigger.focus();
+			trigger!.focus();
 		}
 
-		function navigateOptions(direction) {
+		function navigateOptions(direction: "up" | "down") {
 			if (!isOpen || optionsArray.length === 0) return;
 
 			if (direction === "down") {
@@ -354,12 +364,11 @@ const getVersionUrl = (version: VersionedContent) => {
 			}
 
 			if (currentIndex >= 0 && currentIndex < optionsArray.length) {
-				optionsArray[currentIndex].focus();
+				(optionsArray[currentIndex] as HTMLElement).focus();
 			}
 		}
 
-		// Click/tap to toggle
-		trigger.addEventListener("click", function (e) {
+		const triggerClickHandler = (e: Event) => {
 			e.preventDefault();
 			e.stopPropagation();
 			if (isOpen) {
@@ -367,20 +376,20 @@ const getVersionUrl = (version: VersionedContent) => {
 			} else {
 				openDropdown();
 			}
-		});
+		};
 
-		// Keyboard navigation
-		trigger.addEventListener("keydown", function (e) {
-			switch (e.key) {
+		const triggerKeydownHandler = (e: Event) => {
+			const ke = e as KeyboardEvent;
+			switch (ke.key) {
 				case "Enter":
 				case " ":
-					e.preventDefault();
+					ke.preventDefault();
 					if (!isOpen) {
 						openDropdown();
 					}
 					break;
 				case "ArrowDown":
-					e.preventDefault();
+					ke.preventDefault();
 					if (!isOpen) {
 						openDropdown();
 					} else {
@@ -388,7 +397,7 @@ const getVersionUrl = (version: VersionedContent) => {
 					}
 					break;
 				case "ArrowUp":
-					e.preventDefault();
+					ke.preventDefault();
 					if (isOpen) {
 						navigateOptions("up");
 					}
@@ -399,43 +408,73 @@ const getVersionUrl = (version: VersionedContent) => {
 					}
 					break;
 			}
-		});
+		};
 
-		// Handle keyboard navigation within menu
-		menu.addEventListener("keydown", function (e) {
-			switch (e.key) {
+		const menuKeydownHandler = (e: Event) => {
+			const ke = e as KeyboardEvent;
+			switch (ke.key) {
 				case "ArrowDown":
-					e.preventDefault();
+					ke.preventDefault();
 					navigateOptions("down");
 					break;
 				case "ArrowUp":
-					e.preventDefault();
+					ke.preventDefault();
 					navigateOptions("up");
 					break;
 				case "Escape":
-					e.preventDefault();
+					ke.preventDefault();
 					closeDropdown();
 					break;
 				case "Tab":
-					// Close dropdown and let tab continue naturally
 					closeDropdown();
-					// Don't prevent default to allow normal tab navigation
 					break;
 			}
-		});
+		};
 
-		// Close on outside click
-		document.addEventListener("click", function (e) {
-			if (!dropdown.contains(e.target)) {
+		const outsideClickHandler = (e: Event) => {
+			if (!dropdown.contains(e.target as Node)) {
 				closeDropdown();
 			}
-		});
+		};
 
-		// Close on outside focus (for keyboard users)
-		document.addEventListener("focusin", function (e) {
-			if (!dropdown.contains(e.target)) {
+		const outsideFocusHandler = (e: Event) => {
+			if (!dropdown.contains(e.target as Node)) {
 				closeDropdown();
 			}
-		});
-	});
+		};
+
+		trigger.addEventListener("click", triggerClickHandler);
+		trigger.addEventListener("keydown", triggerKeydownHandler);
+		menu.addEventListener("keydown", menuKeydownHandler);
+		document.addEventListener("click", outsideClickHandler);
+		document.addEventListener("focusin", outsideFocusHandler);
+
+		currentDropdownState = {
+			outsideClickHandler,
+			outsideFocusHandler,
+			triggerClickHandler,
+			triggerKeydownHandler,
+			menuKeydownHandler,
+		};
+	}
+
+	function cleanupVersionDropdown() {
+		if (!currentDropdownState) return;
+		const { outsideClickHandler, outsideFocusHandler, triggerClickHandler, triggerKeydownHandler, menuKeydownHandler } = currentDropdownState;
+
+		const trigger = document.querySelector(".version-dropdown .version-trigger");
+		const menu = document.querySelector(".version-dropdown .version-menu");
+
+		trigger?.removeEventListener("click", triggerClickHandler);
+		trigger?.removeEventListener("keydown", triggerKeydownHandler);
+		menu?.removeEventListener("keydown", menuKeydownHandler);
+		document.removeEventListener("click", outsideClickHandler);
+		document.removeEventListener("focusin", outsideFocusHandler);
+
+		currentDropdownState = null;
+	}
+
+	initVersionDropdown();
+	document.addEventListener("astro:page-load", initVersionDropdown);
+	document.addEventListener("astro:before-swap", cleanupVersionDropdown);
 </script>

--- a/src/components/layouts/navbar/MainNavLinks.astro
+++ b/src/components/layouts/navbar/MainNavLinks.astro
@@ -213,11 +213,24 @@ import PatternIcon from "../../icons/PatternIcon.astro";
 		document.addEventListener("astro:before-preparation", closeMegamenu);
 	}
 
+	function cleanupDropdown() {
+		const button = document.querySelector(".popover-button") as HTMLButtonElement;
+		const handlers = (button as any)?._megamenuHandlers;
+		if (handlers) {
+			button.removeEventListener("click", handlers.click);
+			document.removeEventListener("keydown", handlers.keydown);
+			document.removeEventListener("focusout", handlers.focusout);
+			document.removeEventListener("astro:before-preparation", handlers.beforePrep);
+			(button as any)._megamenuHandlers = null;
+		}
+	}
+
 	// Initialize on page load
 	initializeDropdown();
 
 	// Re-initialize after each navigation
 	document.addEventListener("astro:page-load", initializeDropdown);
+	document.addEventListener("astro:before-swap", cleanupDropdown);
 </script>
 
 <style>

--- a/src/components/layouts/navbar/MainNavLinks.astro
+++ b/src/components/layouts/navbar/MainNavLinks.astro
@@ -109,25 +109,19 @@ import PatternIcon from "../../icons/PatternIcon.astro";
 </div>
 
 <script>
+	import { onPageLifecycle } from "../../../utils/viewTransitionLifecycle";
 
-	function initializeDropdown() {
+	onPageLifecycle(() => {
 		const button = document.querySelector(".popover-button") as HTMLButtonElement;
 		const megamenu = document.getElementById("garden-dropdown") as HTMLElement;
 
 		if (!button || !megamenu) return;
 
-		// Force close on initialization and reset styles
 		function closeMegamenu() {
-			if (!button || !megamenu) return;
-			
 			button.setAttribute("aria-expanded", "false");
-			
-			// Animate out first, then hide
 			megamenu.style.opacity = "0";
 			megamenu.style.transform = "rotateX(-15deg)";
 			megamenu.style.scale = "0.95";
-			
-			// Hide after animation completes
 			setTimeout(() => {
 				if (megamenu.style.opacity === "0") {
 					megamenu.classList.add("hidden");
@@ -136,17 +130,9 @@ import PatternIcon from "../../icons/PatternIcon.astro";
 		}
 
 		function openMegamenu() {
-			if (!megamenu || !button) return;
-			
 			button.setAttribute("aria-expanded", "true");
-			
-			// Show element first, then animate in
 			megamenu.classList.remove("hidden");
-			
-			// Force reflow before animating
-			megamenu.offsetHeight;
-			
-			// Animate in
+			megamenu.offsetHeight; // Force reflow before animating
 			requestAnimationFrame(() => {
 				megamenu.style.opacity = "1";
 				megamenu.style.transform = "rotateX(0deg)";
@@ -154,23 +140,13 @@ import PatternIcon from "../../icons/PatternIcon.astro";
 			});
 		}
 
-		// Initialize closed state immediately without animation
+		// Initialize closed state
 		button.setAttribute("aria-expanded", "false");
 		megamenu.classList.add("hidden");
 		megamenu.style.opacity = "0";
 		megamenu.style.transform = "rotateX(-15deg)";
 		megamenu.style.scale = "0.95";
 
-		// Remove existing listeners to prevent duplicates
-		const existingHandlers = (button as any)._megamenuHandlers;
-		if (existingHandlers) {
-			button.removeEventListener("click", existingHandlers.click);
-			document.removeEventListener("keydown", existingHandlers.keydown);
-			document.removeEventListener("focusout", existingHandlers.focusout);
-			document.removeEventListener("astro:before-preparation", existingHandlers.beforePrep);
-		}
-
-		// Create handler functions
 		const clickHandler = (e: Event) => {
 			e.stopPropagation();
 			if (megamenu.classList.contains("hidden")) {
@@ -180,57 +156,33 @@ import PatternIcon from "../../icons/PatternIcon.astro";
 			}
 		};
 
-		const keydownHandler = (e: KeyboardEvent) => {
-			if (e.key === "Escape" && !megamenu.classList.contains("hidden")) {
+		const keydownHandler = (e: Event) => {
+			if ((e as KeyboardEvent).key === "Escape" && !megamenu.classList.contains("hidden")) {
 				closeMegamenu();
 				button.focus();
 			}
 		};
 
-		const focusoutHandler = (e: FocusEvent) => {
-			const target = e.relatedTarget as Node;
-			// Don't close if clicking a link inside the megamenu
-			if (target && megamenu.contains(target)) {
-				return;
-			}
+		const focusoutHandler = (e: Event) => {
+			const target = (e as FocusEvent).relatedTarget as Node;
+			if (target && megamenu.contains(target)) return;
 			if (!megamenu.contains(target) && !button.contains(target)) {
 				closeMegamenu();
 			}
 		};
 
-		// Store handlers for cleanup
-		(button as any)._megamenuHandlers = {
-			click: clickHandler,
-			keydown: keydownHandler,
-			focusout: focusoutHandler,
-			beforePrep: closeMegamenu
-		};
-
-		// Add event listeners
 		button.addEventListener("click", clickHandler);
 		document.addEventListener("keydown", keydownHandler);
 		document.addEventListener("focusout", focusoutHandler);
 		document.addEventListener("astro:before-preparation", closeMegamenu);
-	}
 
-	function cleanupDropdown() {
-		const button = document.querySelector(".popover-button") as HTMLButtonElement;
-		const handlers = (button as any)?._megamenuHandlers;
-		if (handlers) {
-			button.removeEventListener("click", handlers.click);
-			document.removeEventListener("keydown", handlers.keydown);
-			document.removeEventListener("focusout", handlers.focusout);
-			document.removeEventListener("astro:before-preparation", handlers.beforePrep);
-			(button as any)._megamenuHandlers = null;
-		}
-	}
-
-	// Initialize on page load
-	initializeDropdown();
-
-	// Re-initialize after each navigation
-	document.addEventListener("astro:page-load", initializeDropdown);
-	document.addEventListener("astro:before-swap", cleanupDropdown);
+		return () => {
+			button.removeEventListener("click", clickHandler);
+			document.removeEventListener("keydown", keydownHandler);
+			document.removeEventListener("focusout", focusoutHandler);
+			document.removeEventListener("astro:before-preparation", closeMegamenu);
+		};
+	});
 </script>
 
 <style>

--- a/src/components/search/GardenFilters.astro
+++ b/src/components/search/GardenFilters.astro
@@ -342,7 +342,19 @@ const initialTopicsCount = 6;
 		);
 	}
 
+	function cleanup() {
+		const toggleButton = document.querySelector(".toggle-topics");
+		const topicsList = document.querySelector(".topics-list");
+		const rightMenus = document.querySelector(".right-menus");
+
+		toggleButton?.removeEventListener("click", handleToggleClick);
+		topicsList?.removeEventListener("click", handleTopicClick);
+		rightMenus?.removeEventListener("change", handleSelectChange);
+	}
+
 	function init() {
+		cleanup();
+
 		const toggleButton = document.querySelector(".toggle-topics");
 		const topicsList = document.querySelector(".topics-list");
 		const rightMenus = document.querySelector(".right-menus");
@@ -363,4 +375,5 @@ const initialTopicsCount = 6;
 
 	// Re-initialize after page navigation
 	document.addEventListener("astro:page-load", init);
+	document.addEventListener("astro:before-swap", cleanup);
 </script>

--- a/src/components/search/GardenFilters.astro
+++ b/src/components/search/GardenFilters.astro
@@ -253,6 +253,8 @@ const initialTopicsCount = 6;
 </style>
 
 <script>
+	import { onPageLifecycle } from "../../utils/viewTransitionLifecycle";
+
 	interface FilterState {
 		topic: string;
 		growthStage: string;
@@ -342,38 +344,19 @@ const initialTopicsCount = 6;
 		);
 	}
 
-	function cleanup() {
+	onPageLifecycle(() => {
 		const toggleButton = document.querySelector(".toggle-topics");
 		const topicsList = document.querySelector(".topics-list");
 		const rightMenus = document.querySelector(".right-menus");
 
-		toggleButton?.removeEventListener("click", handleToggleClick);
-		topicsList?.removeEventListener("click", handleTopicClick);
-		rightMenus?.removeEventListener("change", handleSelectChange);
-	}
+		toggleButton?.addEventListener("click", handleToggleClick);
+		topicsList?.addEventListener("click", handleTopicClick);
+		rightMenus?.addEventListener("change", handleSelectChange);
 
-	function init() {
-		cleanup();
-
-		const toggleButton = document.querySelector(".toggle-topics");
-		const topicsList = document.querySelector(".topics-list");
-		const rightMenus = document.querySelector(".right-menus");
-
-		if (toggleButton) {
-			toggleButton.addEventListener("click", handleToggleClick);
-		}
-		if (topicsList) {
-			topicsList.addEventListener("click", handleTopicClick);
-		}
-		if (rightMenus) {
-			rightMenus.addEventListener("change", handleSelectChange);
-		}
-	}
-
-	// Initialize on first load
-	init();
-
-	// Re-initialize after page navigation
-	document.addEventListener("astro:page-load", init);
-	document.addEventListener("astro:before-swap", cleanup);
+		return () => {
+			toggleButton?.removeEventListener("click", handleToggleClick);
+			topicsList?.removeEventListener("click", handleTopicClick);
+			rightMenus?.removeEventListener("change", handleSelectChange);
+		};
+	});
 </script>

--- a/src/components/unique/GarminData.astro
+++ b/src/components/unique/GarminData.astro
@@ -472,6 +472,8 @@ const data = [
 </style>
 
 <script>
+	import { onPageLifecycle } from "../../utils/viewTransitionLifecycle";
+
 	interface GarminDataPoint {
 		date: string;
 		restingHR: number;
@@ -886,20 +888,16 @@ const data = [
 	let resizeTimer: ReturnType<typeof setTimeout>;
 	let resizeHandler: (() => void) | null = null;
 
-	function setup() {
+	onPageLifecycle(() => {
 		const container = document.querySelector(".garmin-chart-container");
 		if (container) initChart();
-	}
 
-	function cleanup() {
-		clearTimeout(resizeTimer);
-		if (resizeHandler) {
-			window.removeEventListener("resize", resizeHandler);
-			resizeHandler = null;
-		}
-	}
-
-	setup();
-	document.addEventListener("astro:page-load", setup);
-	document.addEventListener("astro:before-swap", cleanup);
+		return () => {
+			clearTimeout(resizeTimer);
+			if (resizeHandler) {
+				window.removeEventListener("resize", resizeHandler);
+				resizeHandler = null;
+			}
+		};
+	});
 </script>

--- a/src/components/unique/GarminData.astro
+++ b/src/components/unique/GarminData.astro
@@ -876,17 +876,30 @@ const data = [
 		createChart();
 
 		// Resize handler
-		let resizeTimer: ReturnType<typeof setTimeout>;
-		window.addEventListener("resize", () => {
+		resizeHandler = () => {
 			clearTimeout(resizeTimer);
 			resizeTimer = setTimeout(createChart, 250);
-		});
+		};
+		window.addEventListener("resize", resizeHandler);
 	}
 
-	// Initialize the chart when the DOM is ready
-	if (document.readyState === "loading") {
-		document.addEventListener("DOMContentLoaded", initChart);
-	} else {
-		initChart();
+	let resizeTimer: ReturnType<typeof setTimeout>;
+	let resizeHandler: (() => void) | null = null;
+
+	function setup() {
+		const container = document.querySelector(".garmin-chart-container");
+		if (container) initChart();
 	}
+
+	function cleanup() {
+		clearTimeout(resizeTimer);
+		if (resizeHandler) {
+			window.removeEventListener("resize", resizeHandler);
+			resizeHandler = null;
+		}
+	}
+
+	setup();
+	document.addEventListener("astro:page-load", setup);
+	document.addEventListener("astro:before-swap", cleanup);
 </script>

--- a/src/utils/viewTransitionLifecycle.ts
+++ b/src/utils/viewTransitionLifecycle.ts
@@ -1,0 +1,19 @@
+/**
+ * Registers an init function that runs on first load and after each
+ * view-transition navigation. The init function can return a cleanup
+ * callback that will run before the next init and before DOM swap.
+ */
+export function onPageLifecycle(init: () => (() => void) | void) {
+  let cleanup: (() => void) | void;
+
+  function setup() {
+    if (typeof cleanup === "function") cleanup();
+    cleanup = init();
+  }
+
+  setup();
+  document.addEventListener("astro:page-load", setup);
+  document.addEventListener("astro:before-swap", () => {
+    if (typeof cleanup === "function") cleanup();
+  });
+}


### PR DESCRIPTION
## Summary

- Fixes stale event listeners after Astro View Transitions soft navigation in 5 components: VersionDropdown, GarminData, TableOfContents, GardenFilters, and MainNavLinks
- Replaces `DOMContentLoaded` (which never fires after soft nav) with `astro:page-load` in VersionDropdown and GarminData
- Adds symmetric `astro:before-swap` cleanup handlers so global listeners (window scroll/resize, document click/keydown/focusin) are properly removed before DOM swap and re-attached on page load
- Tracks `setTimeout` IDs for proper cleanup in TableOfContents and GarminData

Closes #27

## Test plan

- [ ] Navigate to a page with the version dropdown, navigate away, navigate back — verify dropdown still opens/closes
- [ ] Navigate to the Garmin data page, navigate away and back — verify chart redraws on window resize
- [ ] Navigate to a page with TOC, navigate away and back — verify scroll-based auto-collapse and TOC link smooth scrolling still work
- [ ] Navigate to the garden page, navigate away and back — verify topic filters and growth stage selects still work
- [ ] Navigate to a page with the navbar megamenu, navigate away and back — verify dropdown opens and Escape closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)