### PR TITLE
Fix all 15 astro check type errors

### DIFF
--- a/src/components/mdx/Accordion.astro
+++ b/src/components/mdx/Accordion.astro
@@ -181,7 +181,7 @@ const { header } = Astro.props;
 					if (panel instanceof HTMLElement) {
 						panel.style.display = "block"; // Ensure panel is visible for animation
 						panel.classList.add("open");
-						animate(
+						(animate as any)(
 							panel,
 							{
 								height: ["0px", `${panel.scrollHeight}px`],
@@ -206,7 +206,7 @@ const { header } = Astro.props;
 					// Closing animation
 					if (panel instanceof HTMLElement) {
 						panel.style.height = `${panel.scrollHeight}px`; // Set current height before animating
-						animate(
+						(animate as any)(
 							panel,
 							{
 								height: [`${panel.scrollHeight}px`, "0px"],

--- a/src/components/unique/ChatHistoryTabs.astro
+++ b/src/components/unique/ChatHistoryTabs.astro
@@ -49,20 +49,21 @@ const {
 
 		function updateStackHeight() {
 			// Set container height based on active image
-			const activeImage = container.querySelector(".chat-image.active");
-			if (activeImage && imagesStack) {
+			const activeImage = container!.querySelector(".chat-image.active") as HTMLImageElement | null;
+			const stack = imagesStack as HTMLElement | null;
+			if (activeImage && stack) {
 				// Wait for image to load if not already loaded
 				if (activeImage.complete) {
-					imagesStack.style.height = `${activeImage.offsetHeight}px`;
+					stack.style.height = `${activeImage.offsetHeight}px`;
 				} else {
 					activeImage.addEventListener("load", () => {
-						imagesStack.style.height = `${activeImage.offsetHeight}px`;
+						stack.style.height = `${activeImage.offsetHeight}px`;
 					});
 				}
 			}
 		}
 
-		function switchTab(tabName) {
+		function switchTab(tabName: string) {
 			// Update tab buttons
 			tabs.forEach((tab) => {
 				if (tab.getAttribute("data-tab") === tabName) {
@@ -89,7 +90,7 @@ const {
 		tabs.forEach((tab) => {
 			tab.addEventListener("click", () => {
 				const tabName = tab.getAttribute("data-tab");
-				switchTab(tabName);
+				if (tabName) switchTab(tabName);
 			});
 		});
 

--- a/src/components/unique/css-position/StickyPosition.astro
+++ b/src/components/unique/css-position/StickyPosition.astro
@@ -168,7 +168,7 @@
 					filter-units="userSpaceOnUse"
 					color-interpolation-filters="sRGB"
 				>
-					<feFlood floodOpacity={0} result="BackgroundImageFix"></feFlood>
+					<feFlood flood-opacity="0" result="BackgroundImageFix"></feFlood>
 					<feColorMatrix
 						in="SourceAlpha"
 						values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -39,7 +39,7 @@ const canonicalURL = entry
 	: undefined;
 
 // Get canonical dates for versioned content (consistent across all versions)
-let canonicalDates = {
+let canonicalDates: { startDate: Date; updated?: Date } = {
 	startDate: frontmatter.startDate,
 	updated: frontmatter.updated,
 };
@@ -62,8 +62,8 @@ if (entry) {
 	}
 	const versionedDates = getCanonicalDates(entry, allEntries);
 	canonicalDates = {
-		startDate: versionedDates.startDate,
-		updated: versionedDates.updated,
+		startDate: new Date(versionedDates.startDate),
+		updated: versionedDates.updated ? new Date(versionedDates.updated) : undefined,
 	};
 }
 

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -122,7 +122,7 @@ const frontmatter = entry.data;
 			</ProseWrapper>
 		</SmidgeonLayout>
 	) : (
-		<PostLayout frontmatter={frontmatter} headings={headings} entry={entry}>
+		<PostLayout frontmatter={frontmatter} headings={headings} entry={entry as CollectionEntry<"essays"> | CollectionEntry<"notes"> | CollectionEntry<"patterns"> | CollectionEntry<"talks">}>
 			<ProseWrapper>
 				{headings.length > 0 && hasTOC(frontmatter) && frontmatter.toc && (
 					<TableOfContents headings={headings} />

--- a/src/pages/colophon/index.astro
+++ b/src/pages/colophon/index.astro
@@ -9,12 +9,12 @@ import TooltipLink from "../../components/mdx/TooltipLink.astro";
 import Content from "./colophon-content.mdx";
 import type { MDXComponents } from "mdx/types";
 
-const components: MDXComponents = {
+const components = {
 	h1: Title1,
 	h2: Title2,
 	h3: Title3,
 	a: TooltipLink,
-};
+} as unknown as MDXComponents;
 ---
 
 <Layout title="Colophon of Maggie Appleton">

--- a/src/pages/og.png.ts
+++ b/src/pages/og.png.ts
@@ -261,7 +261,7 @@ export const GET: APIRoute = async function get({ request }) {
     },
   };
 
-  const svg = await satori(content, {
+  const svg = await satori(content as any, {
     width: 1200,
     height: 630,
     fonts: [


### PR DESCRIPTION
## Summary
- Fixes all 15 TypeScript errors reported by `npx astro check` across 7 files
- Adds proper DOM type casts and null guards in ChatHistoryTabs (6 errors)
- Adds explicit Date typing and coercion in PostLayout (2 errors)
- Works around `motion` library overload mismatch in Accordion (2 errors)
- Narrows collection entry types in `[...slug].astro` to exclude smidgeons (1 error)
- Adds cross-ecosystem type casts for satori and MDX components (2 errors)
- Uses kebab-case SVG attribute in StickyPosition (1 error)

## Test plan
- [ ] Run `npx astro check` and confirm 0 errors
- [ ] Run `npx astro build` to confirm no build regressions
- [ ] Spot-check accordion expand/collapse, chat history tabs, and colophon page

🤖 Generated with [Claude Code](https://claude.com/claude-code)