### PR TITLE
Convert 4 talks from TalkSlide to ScrollyTalkSection

### DIFF
--- a/src/content/talks/forest-talk.mdx
+++ b/src/content/talks/forest-talk.mdx
@@ -20,7 +20,7 @@ cover: "../../images/covers/talk-forest@2x.png"
 
 import Video from "../../components/mdx/Video.astro";
 import Center from "../../components/mdx/Center.astro";
-import TalkSlide from "../../components/mdx/TalkSlide.astro";
+import ScrollyTalkSection from "../../components/mdx/ScrollyTalkSection.astro";
 import YearsAgo from "../../components/mdx/YearsAgo.astro";
 import ReferencesLink from "../../components/mdx/ReferencesLink.astro";
 
@@ -107,1228 +107,1233 @@ First presented at [Causal Islands](https://www.causalislands.com/) in Toronto, 
 ## Slides and Transcript
 
 <BasicImage width="1200px" src="/images/posts/forest-talk/dft_1.jpeg" />
+<ScrollyTalkSection images={[
+  "/images/posts/forest-talk/dft_2.jpeg",
+  "/images/posts/forest-talk/dft_3.jpeg",
+  "/images/posts/forest-talk/dft_4.jpeg",
+  "/images/posts/forest-talk/dft_6.jpeg",
+  "/images/posts/forest-talk/dft_8.jpeg",
+  "/images/posts/forest-talk/dft_9.jpeg",
+  "/images/posts/forest-talk/dft_10.jpeg",
+  "/images/posts/forest-talk/dft_11.jpeg",
+  "/images/posts/forest-talk/dft_13.jpeg",
+  "/images/posts/forest-talk/dft_14.jpeg",
+  "/images/posts/forest-talk/dft_15.jpeg",
+  "/images/posts/forest-talk/dft_16.jpeg",
+  "/images/posts/forest-talk/dft_17.jpeg",
+  "/images/posts/forest-talk/dft_18.jpeg",
+  "/images/posts/forest-talk/dft_19.jpeg",
+  "/images/posts/forest-talk/dft_20.jpeg",
+  "/images/posts/forest-talk/dft_21.jpeg",
+  "/images/posts/forest-talk/dft_22.jpeg",
+  "/images/posts/forest-talk/dft_23.jpeg",
+  "/images/posts/forest-talk/dft_24.jpeg",
+  "/images/posts/forest-talk/dft_25.jpeg",
+  "/images/posts/forest-talk/dft_26.jpeg",
+  "/images/posts/forest-talk/dft_27.jpeg",
+  "/images/posts/forest-talk/dft_29.jpeg",
+  "/images/posts/forest-talk/dft_30.jpeg",
+  "/images/posts/forest-talk/dft_31.jpeg",
+  "/images/posts/forest-talk/dft_32.jpeg",
+  "/images/posts/forest-talk/dft_33.jpeg",
+  "/images/posts/forest-talk/dft_34.jpeg",
+  "/images/posts/forest-talk/dft_35.jpeg",
+  "/images/posts/forest-talk/dft_36.jpeg",
+  "/images/posts/forest-talk/dft_37.jpeg",
+  "/images/posts/forest-talk/dft_38.jpeg",
+  "/images/posts/forest-talk/dft_39.jpeg",
+  "/images/posts/forest-talk/dft_40.jpeg",
+  "/images/posts/forest-talk/dft_41.jpeg",
+  "/images/posts/forest-talk/dft_42.jpeg",
+  "/images/posts/forest-talk/dft_43.jpeg",
+  "/images/posts/forest-talk/dft_44.jpeg",
+  "/images/posts/forest-talk/dft_45.jpeg",
+  "/images/posts/forest-talk/dft_46.jpeg",
+  "/images/posts/forest-talk/dft_48.jpeg",
+  "/images/posts/forest-talk/dft_51.jpeg",
+  "/images/posts/forest-talk/dft_52.jpeg",
+  "/images/posts/forest-talk/dft_53.jpeg",
+  "/images/posts/forest-talk/dft_54.jpeg",
+  "/images/posts/forest-talk/dft_55.jpeg",
+  "/images/posts/forest-talk/dft_56.jpeg",
+  "/images/posts/forest-talk/dft_57.jpeg",
+  "/images/posts/forest-talk/dft_58.jpeg",
+  "/images/posts/forest-talk/dft_59.jpeg",
+  "/images/posts/forest-talk/dft_60.jpeg",
+  "/images/posts/forest-talk/dft_61.jpeg",
+  "/images/posts/forest-talk/dft_62.jpeg",
+  "/images/posts/forest-talk/dft_62 2.jpeg",
+  "/images/posts/forest-talk/dft_62 3.jpeg",
+  "/images/posts/forest-talk/dft_62 4.jpeg",
+  "/images/posts/forest-talk/dft_62 5.jpeg",
+  "/images/posts/forest-talk/dft_62 6.jpeg",
+  "/images/posts/forest-talk/dft_62 7.jpeg",
+  "/images/posts/forest-talk/dft_62 8.jpeg",
+  "/images/posts/forest-talk/dft_62 9.jpeg",
+  "/images/posts/forest-talk/dft_62 10.jpeg",
+  "/images/posts/forest-talk/dft_62 11.jpeg",
+  "/images/posts/forest-talk/dft_62 12.jpeg",
+  "/images/posts/forest-talk/dft_63.jpeg",
+  "/images/posts/forest-talk/dft_64.jpeg",
+  "/images/posts/forest-talk/dft_65.jpeg",
+  "/images/posts/forest-talk/dft_66.jpeg",
+  "/images/posts/forest-talk/dft_67.jpeg",
+  "/images/posts/forest-talk/dft_68.jpeg",
+  "/images/posts/forest-talk/dft_69.jpeg",
+  "/images/posts/forest-talk/dft_70.jpeg",
+  "/images/posts/forest-talk/dft_71.jpeg",
+  "/images/posts/forest-talk/dft_72.jpeg",
+  "/images/posts/forest-talk/dft_73.jpeg",
+  "/images/posts/forest-talk/dft_74.jpeg",
+  "/images/posts/forest-talk/dft_75.jpeg",
+  "/images/posts/forest-talk/dft_76.jpeg",
+  "/images/posts/forest-talk/dft_77.jpeg",
+  "/images/posts/forest-talk/dft_78.jpeg",
+  "/images/posts/forest-talk/dft_79.jpeg",
+  "/images/posts/forest-talk/dft_80.jpeg",
+  "/images/posts/forest-talk/dft_81.jpeg",
+  "/images/posts/forest-talk/dft_82.jpeg",
+  "/images/posts/forest-talk/dft_83.jpeg",
+  "/images/posts/forest-talk/dft_83.1.jpeg",
+  "/images/posts/forest-talk/dft_84.jpeg",
+  "/images/posts/forest-talk/dft_85.jpeg",
+  "/images/posts/forest-talk/dft_86.jpeg",
+  "/images/posts/forest-talk/dft_87.jpeg",
+  "/images/posts/forest-talk/dft_88.jpeg",
+  "/images/posts/forest-talk/dft_89.jpeg",
+  "/images/posts/forest-talk/dft_90.jpeg",
+  "/images/posts/forest-talk/dft_91.jpeg",
+  "/images/posts/forest-talk/dft_92.jpeg",
+  "/images/posts/forest-talk/dft_93.jpeg",
+  "/images/posts/forest-talk/dft_94.jpeg",
+  "/images/posts/forest-talk/dft_95.jpeg",
+  "/images/posts/forest-talk/dft_96.jpeg",
+  "/images/posts/forest-talk/dft_97.jpeg",
+  "/images/posts/forest-talk/dft_98.jpeg",
+  "/images/posts/forest-talk/dft_99.jpeg",
+  "/images/posts/forest-talk/dft_100.jpeg",
+  "/images/posts/forest-talk/dft_101.jpeg",
+  "/images/posts/forest-talk/dft_102.jpeg",
+  "/images/posts/forest-talk/dft_103.jpeg",
+  "/images/posts/forest-talk/dft_104.jpeg",
+  "/images/posts/forest-talk/dft_105.jpeg",
+  "/images/posts/forest-talk/dft_106.jpeg",
+  "/images/posts/forest-talk/dft_107.jpeg",
+  "/images/posts/forest-talk/dft_108.jpeg",
+  "/images/posts/forest-talk/dft_109.jpeg",
+  "/images/posts/forest-talk/dft_110.jpeg",
+  "/images/posts/forest-talk/dft_111.jpeg",
+  "/images/posts/forest-talk/dft_112.jpeg",
+  "/images/posts/forest-talk/dft_113.jpeg",
+  "/images/posts/forest-talk/dft_114.jpeg",
+  "/images/posts/forest-talk/dft_115.jpeg",
+  "/images/posts/forest-talk/dft_116.jpeg",
+  "/images/posts/forest-talk/dft_117.jpeg",
+]}>
+<div data-slide="0">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_2.jpeg">
+  This is going to be about writing on the web, trust, and human relationships (small fish)
 
-This is going to be about writing on the web, trust, and human relationships (small fish)
+  </div>
+  <div data-slide="1">
 
-</TalkSlide>
+  And inevitably, AI. Sorry.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_3.jpeg">
+  A small footnote: this talk up to date as of about 2 weeks ago which means everything I say about the current state of AI is probably completely irrelevant by now.
 
-And inevitably, AI. Sorry.
+  I have essentially gathered some thoughts that relate to a moment in time that has just whooshed past us.
 
-A small footnote: this talk up to date as of about 2 weeks ago which means everything I say about the current state of AI is probably completely irrelevant by now.
+  </div>
+  <div data-slide="2">
 
-I have essentially gathered some thoughts that relate to a moment in time that has just whooshed past us.
+  First, some context. I’m Maggie and I want to lay out all my biases up front.
 
-</TalkSlide>
+  I’m a designer at an AI research lab called [Elicit](https://elicit.org/). My job involves creating tools that use language models to augment and expand human reasoning.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_4.jpeg">
+  In practice, these tools are primarily aimed at academics and large organizations such as governments and non-profits, helping them to understand scientific literature and make decisions.
 
-First, some context. I’m Maggie and I want to lay out all my biases up front.
+  Secondly, I’m what we call “very online”. I live on Twitter and write a lot online. I hang out with people who do the same, and we write blog posts and essays to each other while researching. As if we're 18th-century men of letters. This has led to lots of friends and collaborators and wonderful jobs.
 
-I’m a designer at an AI research lab called [Elicit](https://elicit.org/). My job involves creating tools that use language models to augment and expand human reasoning.
+  Being a sincere human on the web has been an overwhelmingly positive experience for me, and I want others to have that same experience.
 
-In practice, these tools are primarily aimed at academics and large organizations such as governments and non-profits, helping them to understand scientific literature and make decisions.
+  Lastly, before I joined tech, I studied cultural anthropology. I like to think this gives me some useful perspectives, frameworks, and tools to think about culture and social behaviour on the web.
 
-Secondly, I’m what we call “very online”. I live on Twitter and write a lot online. I hang out with people who do the same, and we write blog posts and essays to each other while researching. As if we're 18th-century men of letters. This has led to lots of friends and collaborators and wonderful jobs.
+  </div>
+  <div data-slide="3">
 
-Being a sincere human on the web has been an overwhelmingly positive experience for me, and I want others to have that same experience.
+  I’ll first discuss the dark forest theory of the web, then talk about the state of generative AI.
 
-Lastly, before I joined tech, I studied cultural anthropology. I like to think this gives me some useful perspectives, frameworks, and tools to think about culture and social behaviour on the web.
+  We'll then consider if we have a problem here. I’ll lay out hypothetical problems and examine if they’re valid.
 
-</TalkSlide>
+  Then we'll cover possible futures and how to deal with those hypothetical problems.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_6.jpeg">
+  </div>
+  <div data-slide="4">
 
-I’ll first discuss the dark forest theory of the web, then talk about the state of generative AI.
+  To explain the dark forest theory of the web, I first need to explain the dark forest theory of the universe. This theory attempts to explain why we haven’t yet discovered intelligent life in the universe.
 
-We'll then consider if we have a problem here. I’ll lay out hypothetical problems and examine if they’re valid.
+  </div>
+  <div data-slide="5">
 
-Then we'll cover possible futures and how to deal with those hypothetical problems.
+  Here we are - the pale blue dot
 
-</TalkSlide>
+  </div>
+  <div data-slide="6">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_8.jpeg">
+  As the only known intelligent life in the universe, we’ve been beaming out messages for 60 years in an attempt to find others.
 
-To explain the dark forest theory of the web, I first need to explain the dark forest theory of the universe. This theory attempts to explain why we haven’t yet discovered intelligent life in the universe.
+  But we haven’t heard anything back yet.
 
-</TalkSlide>
+  Dark forest theory suggests that the universe is like a dark forest at night - a place that appears quiet and lifeless because if you make noise...
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_9.jpeg">
+  </div>
+  <div data-slide="7">
 
-Here we are - the pale blue dot
+  ...the predators will come eat you.
 
-</TalkSlide>
+  This theory proposes that all other intelligent civilizations were either killed or learned to shut up. We don’t yet know which category we fall into.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_10.jpeg">
+  </div>
+  <div data-slide="8">
 
-As the only known intelligent life in the universe, we’ve been beaming out messages for 60 years in an attempt to find others.
+  The web version builds off that concept
 
-But we haven’t heard anything back yet.
+  </div>
+  <div data-slide="9">
 
-Dark forest theory suggests that the universe is like a dark forest at night - a place that appears quiet and lifeless because if you make noise...
+  This is a theory proposed by Yancey Striker in 2019 in the article [The Dark Forest Theory of the Internet](https://onezero.medium.com/the-dark-forest-theory-of-the-internet-7dc3e68a7cb1)
 
-</TalkSlide>
+  Yancey describes some trends and shifts around what it feels like to be in the public spaces of the web.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_11.jpeg">
+  </div>
+  <div data-slide="10">
 
-...the predators will come eat you.
+  Yancey pointed out two main “vibes”. First, the web can often feel lifeless, automated, and devoid of humans.
 
-This theory proposes that all other intelligent civilizations were either killed or learned to shut up. We don’t yet know which category we fall into.
+  </div>
+  <div data-slide="11">
 
-</TalkSlide>
+  Here we are on the web
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_13.jpeg">
+  And we're naively writing a bunch of sincere and authentic accounts of our lives and thoughts and experiences. Trying to find other intelligent people who share our beliefs and interests
 
-The web version builds off that concept
+  </div>
+  <div data-slide="12">
 
-</TalkSlide>
+  But feels like we’re surrounded by content that doesn’t feel authentic and human.
+  Lots of this content is authored by bots, marketing automation, and growth hackers pumping out generic clickbait with ulterior motives.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_14.jpeg">
+  </div>
+  <div data-slide="13">
 
-This is a theory proposed by Yancey Striker in 2019 in the article [The Dark Forest Theory of the Internet](https://onezero.medium.com/the-dark-forest-theory-of-the-internet-7dc3e68a7cb1)
+  We have all seen this stuff.
 
-Yancey describes some trends and shifts around what it feels like to be in the public spaces of the web.
+  Low-quality listicles...
 
-</TalkSlide>
+  </div>
+  <div data-slide="14">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_15.jpeg">
+  ...productivity rubbish...
 
-Yancey pointed out two main “vibes”. First, the web can often feel lifeless, automated, and devoid of humans.
+  </div>
+  <div data-slide="15">
 
-</TalkSlide>
+  ...insincere templated crap...
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_16.jpeg">
+  </div>
+  <div data-slide="16">
 
-Here we are on the web
+  ...growth hacking advice...
 
-And we're naively writing a bunch of sincere and authentic accounts of our lives and thoughts and experiences. Trying to find other intelligent people who share our beliefs and interests
+  </div>
+  <div data-slide="17">
 
-</TalkSlide>
+  ...banal motivational quotes...
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_17.jpeg">
+  </div>
+  <div data-slide="18">
 
-But feels like we’re surrounded by content that doesn’t feel authentic and human.
-Lots of this content is authored by bots, marketing automation, and growth hackers pumping out generic clickbait with ulterior motives.
+  ...and dramatic clickbait.
 
-</TalkSlide>
+  </div>
+  <div data-slide="19">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_18.jpeg">
+  This stuff may as well be automated. It's rarely trying to communicate sincere and original thoughts and ideas to other humans. Mostly trying to get you to click and rack up views.
 
-We have all seen this stuff.
+  The overwhelming flood of this low-quality content makes us retreat away from public spaces of the web. It's too costly to spend our time and energy wading through it.
 
-Low-quality listicles...
+  </div>
+  <div data-slide="20">
 
-</TalkSlide>
+  The second vibe of the dark forest web is lots of unnecessarily antagonistic behaviour, at scale.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_19.jpeg">
+  </div>
+  <div data-slide="21">
 
-...productivity rubbish...
+  When we put out signals trying to connect with other humans, we risk becoming a target.
 
-</TalkSlide>
+  </div>
+  <div data-slide="22">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_20.jpeg">
+  Specifically, the Twitter mob might come to eat us.
 
-...insincere templated crap...
+  </div>
+  <div data-slide="23">
 
-</TalkSlide>
+  There’s a term on Twitter called getting “main charactered”.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_21.jpeg">
+  Every day there is one main character on Twitter and your goal is to not be that character. They get piled on by everyone for saying the wrong thing.
+  Sometimes they deserve it, but it's often quite arbitrary. I’ve had close friends get main charactered for frankly very banal and minor things
 
-...growth hacking advice...
+  A good example of this is garden lady from October.
 
-</TalkSlide>
+  Some of you may have seen this. This woman tweeted this lovely, sweet message about loving her husband and spending hours every morning talking to him in the garden over coffee.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_22.jpeg">
+  </div>
+  <div data-slide="24">
 
-...banal motivational quotes...
+  The replies were priceless
 
-</TalkSlide>
+  </div>
+  <div data-slide="25">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_23.jpeg">
 
-...and dramatic clickbait.
+  </div>
+  <div data-slide="26">
 
-</TalkSlide>
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_24.jpeg">
+  </div>
+  <div data-slide="27">
 
-This stuff may as well be automated. It's rarely trying to communicate sincere and original thoughts and ideas to other humans. Mostly trying to get you to click and rack up views.
+  TikTok captured this vibe well – "I don't really care if something good happened to you. It should have happened to me instead."
 
-The overwhelming flood of this low-quality content makes us retreat away from public spaces of the web. It's too costly to spend our time and energy wading through it.
+  </div>
+  <div data-slide="28">
 
-</TalkSlide>
+  In his book “So You’ve Been Publicly Shamed,” Jon Ronson explores how cancelling and publicly shaming others has become a common practice on social media.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_25.jpeg">
+  This phenomenon has real material consequences for people, causing them to lose their jobs, become alienated from their communities, and suffer emotional trauma.
 
-The second vibe of the dark forest web is lots of unnecessarily antagonistic behaviour, at scale.
+  Many people choose not to engage on the public web because it's become a sincerely dangerous place to express your true thoughts.
 
-</TalkSlide>
+  </div>
+  <div data-slide="29">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_26.jpeg">
+  It’s difficult to find people who are being sincere, seeking coherence, and building collective knowledge in public.
 
-When we put out signals trying to connect with other humans, we risk becoming a target.
+  While I understand that not everyone wants to engage in these activities on the web all the time, some people just want to dance on TikTok, and that’s fine!
 
-</TalkSlide>
+  However, I’m interested in enabling productive discourse and community building on at least some parts of the web. I imagine that others here feel the same way.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_27.jpeg">
+  Rather than being a primarily threatening and inhuman place where nothing is taken in good faith.
 
-Specifically, the Twitter mob might come to eat us.
+  </div>
+  <div data-slide="30">
 
-</TalkSlide>
+  So, how do we cope with this?
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_29.jpeg">
+  While wandering around the dark forest of Facebook and Linked in and Twitter, most of us realised we need to go somewhere safer.
 
-There’s a term on Twitter called getting “main charactered”.
+  </div>
+  <div data-slide="31">
 
-Every day there is one main character on Twitter and your goal is to not be that character. They get piled on by everyone for saying the wrong thing.
-Sometimes they deserve it, but it's often quite arbitrary. I’ve had close friends get main charactered for frankly very banal and minor things
+  We end up retreating to what’s been called the “cozy web.”
 
-A good example of this is garden lady from October.
+  This term was coined by Venkat Rao in [The Extended Internet Universe](https://studio.ribbonfarm.com/p/the-extended-internet-universe) – a direct response to the dark forest theory of the web. Venkat pointed out that we’ve all started going underground, as if were.
 
-Some of you may have seen this. This woman tweeted this lovely, sweet message about loving her husband and spending hours every morning talking to him in the garden over coffee.
+  We move to semi-private spaces like newsletters and personal websites where we’re less at risk of attack.
 
-</TalkSlide>
+  </div>
+  <div data-slide="32">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_30.jpeg">
+  However, even personal websites and newsletters can sometimes be too public, so we retreat further into gatekept private chat apps like Slack, Discord, and WhatsApp.
 
-The replies were priceless
+  These apps allow us to spend most of our time in real human relationships and express our ideas, with things we say taken in good faith and opportunities for real discussions.
 
-</TalkSlide>
+  The problem is that none of this is indexed or searchable, and we’re hiding collective knowledge in private databases that we don’t own. Good luck searching on Discord!
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_31.jpeg">
+  </div>
+  <div data-slide="33">
 
-</TalkSlide>
+  My current theory is that the dark forest parts of the web are about to expand.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_32.jpeg">
+  </div>
+  <div data-slide="34">
 
-</TalkSlide>
+  We now have what’s being called generative AI
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_33.jpeg">
+  These are machine-learning models that can generate content that before this point in history, only humans could make. This includes text, images, videos, and audio.
 
-TikTok captured this vibe well – "I don't really care if something good happened to you. It should have happened to me instead."
+  </div>
+  <div data-slide="35">
 
-</TalkSlide>
+  Here are some some popular models for each media type.
+  I’m sure you’ve all heard of some of these.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_34.jpeg">
+  </div>
+  <div data-slide="36">
 
-In his book “So You’ve Been Publicly Shamed,” Jon Ronson explores how cancelling and publicly shaming others has become a common practice on social media.
+  Obviously, this is ChatGPT. We've all seen thousands of screenshots of this.
 
-This phenomenon has real material consequences for people, causing them to lose their jobs, become alienated from their communities, and suffer emotional trauma.
+  It's a large language model that can generate huge volumes of human-like text in seconds.
 
-Many people choose not to engage on the public web because it's become a sincerely dangerous place to express your true thoughts.
+  I’m going to assume a fair amount of knowledge about language models in this crowd.
 
-</TalkSlide>
+  The key points to know are:
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_35.jpeg">
+  - Its outputs are generally indistinguishable from human-made text, roughly at a high school essay level. We should acknowledge that these outputs are astonishingly good. I'll get to the flaws and weaknesses of language models later.
+  - They're trained on a huge volume of text scraped primarily from the English-speaking web.
+  - All language models do is predict the next word in a sequence, which may sound simple but leads to all kinds of complex and potentially useful behaviour.
 
-It’s difficult to find people who are being sincere, seeking coherence, and building collective knowledge in public.
+  </div>
+  <div data-slide="37">
 
-While I understand that not everyone wants to engage in these activities on the web all the time, some people just want to dance on TikTok, and that’s fine!
+  We can also generate images. These are outputs from Midjourney.
 
-However, I’m interested in enabling productive discourse and community building on at least some parts of the web. I imagine that others here feel the same way.
+  </div>
+  <div data-slide="38">
 
-Rather than being a primarily threatening and inhuman place where nothing is taken in good faith.
+  We can also do videos. This is a demo of OpenAI's [SORA model](https://www.youtube.com/watch?v=HK6y8DAPN_0)
 
-</TalkSlide>
+  This is still in the uncanny valley stage.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_36.jpeg">
+  I'm not going to focus on video and image outputs for this talk.
+  I'm just going to focus on language models.
 
-So, how do we cope with this?
+  Deepfakes are a problem, but I’m all full up on problems.
+  Someone else is going to have to do that talk.
 
-While wandering around the dark forest of Facebook and Linked in and Twitter, most of us realised we need to go somewhere safer.
+  </div>
+  <div data-slide="39">
 
-</TalkSlide>
+  By now language models have been turned into lots of easy-to-use products. You don't need any understanding of models or technical skills to use them. They come baked-into many existing popular tools like Photoshop or Notion.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_37.jpeg">
+  </div>
+  <div data-slide="40">
 
-We end up retreating to what’s been called the “cozy web.”
+  The product category that concerns me most is content generators. These are tools designed for marketers and SEO strategists to easily create publishable content.
 
-This term was coined by Venkat Rao in [The Extended Internet Universe](https://studio.ribbonfarm.com/p/the-extended-internet-universe) – a direct response to the dark forest theory of the web. Venkat pointed out that we’ve all started going underground, as if were.
+  I'm going to pick on one called [Blaze](https://www.blaze.ai/) but there are plenty of other tools that do the same thing.
 
-We move to semi-private spaces like newsletters and personal websites where we’re less at risk of attack.
+  They tend to work like this: You type in what you want to write about. I’ve said "why plant-based meat is morally wrong" here. This isn't an opinion I agree with but it sounds like a good topic for clickbait.
 
-</TalkSlide>
+  </div>
+  <div data-slide="41">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_38.jpeg">
+  So I’ll have this model write an article for me.
 
-However, even personal websites and newsletters can sometimes be too public, so we retreat further into gatekept private chat apps like Slack, Discord, and WhatsApp.
+  And then it churns out 700 words on it.
+  This is now ready for me to publish.
 
-These apps allow us to spend most of our time in real human relationships and express our ideas, with things we say taken in good faith and opportunities for real discussions.
+  Which if I’m someone lobbying against carbon credits is handy.
 
-The problem is that none of this is indexed or searchable, and we’re hiding collective knowledge in private databases that we don’t own. Good luck searching on Discord!
+  I can generate 100 of these, optimise them for Google search terms, and shove them on the web.
 
-</TalkSlide>
+  A hard day’s advocacy done!
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_39.jpeg">
+  The quality and truthfulness of this is clearly questionable, but we’ll get to the problems with it later.
 
-My current theory is that the dark forest parts of the web are about to expand.
+  The point is this is very easy to do.
 
-</TalkSlide>
+  This isn't limited to blog posts and articles.
+  Any text that can be generated will.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_40.jpeg">
+  They give you an array of convenient formats.
+  Like presenting yourself on a dating site and wedding vows.
+  Or “sharing tips and knowledge”. Though clearly not based off anything you’ve actually learned.
 
-We now have what’s being called generative AI
+  </div>
+  <div data-slide="42">
 
-These are machine-learning models that can generate content that before this point in history, only humans could make. This includes text, images, videos, and audio.
+  There’s every manifestation of this; Tweet generators, Linked In post generators, turn YouTube videos into tweets and vice versa.
 
-</TalkSlide>
+  You're able to reuse content quite easily. This is all a marketer's dream!
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_41.jpeg">
+  </div>
+  <div data-slide="43">
 
-Here are some some popular models for each media type.
-I’m sure you’ve all heard of some of these.
+  Most of the tools and examples I’ve shown so far have a fairly simple architecture.
 
-</TalkSlide>
+  They’re made by feeding a single input, or prompt, into the big black mystery box of a language model. (We call them black boxes because we don't know that much about how they reason or produce answers. It's a mystery to everyone, including their creators.)
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_42.jpeg">
+  And we get a single output – an image, some text, or an article.
 
-Obviously, this is ChatGPT. We've all seen thousands of screenshots of this.
+  </div>
+  <div data-slide="44">
 
-It's a large language model that can generate huge volumes of human-like text in seconds.
+  We can scale that up to many outputs.
 
-I’m going to assume a fair amount of knowledge about language models in this crowd.
+  Most companies that make language models have an API you can hit. So we can ask for 1,000 or 100,000 articles.
 
-The key points to know are:
+  But we’re still limited in how sophisticated we can get with these outputs.
 
-- Its outputs are generally indistinguishable from human-made text, roughly at a high school essay level. We should acknowledge that these outputs are astonishingly good. I'll get to the flaws and weaknesses of language models later.
-- They're trained on a huge volume of text scraped primarily from the English-speaking web.
-- All language models do is predict the next word in a sequence, which may sound simple but leads to all kinds of complex and potentially useful behaviour.
+  </div>
+  <div data-slide="45">
 
-</TalkSlide>
+  Recently, people have been developing more sophisticated methods of prompting language models, such as "prompt chaining" or composition.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_43.jpeg">
+  Ought has been [researching this](https://ought.org/research/factored-cognition) for a few years. Recently released libraries like [LangChain](https://python.langchain.com/en/latest/) make it much easier to do.
 
-We can also generate images. These are outputs from Midjourney.
+  This approach solves many of the weaknesses of language models, such as a lack of knowledge of recent events, inaccuracy, difficulty with mathematics, lack of long-term memory, and their inability to interact with the rest of our digital systems.
 
-</TalkSlide>
+  Prompt chaining is a way of setting up a language model to mimic a reasoning loop in combination with external tools.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_44.jpeg">
+  You give it a goal to achieve, and then the model loops through a set of steps: it observes and reflects on what it knows so far and then decides on a course of action. It can pick from a set of tools to help solve the problem, such as searching the web, writing and running code, querying a database, using a calculator, hitting an API, connecting to Zapier or IFTTT, etc.
 
-We can also do videos. This is a demo of OpenAI's [SORA model](https://www.youtube.com/watch?v=HK6y8DAPN_0)
+  After each action, the model reflects on what it's learned and then picks another action, continuing the loop until it arrives at the final output.
 
-This is still in the uncanny valley stage.
+  This gives us much more sophisticated answers than a single language model call, making them more accurate and able to do more complex tasks.
 
-I'm not going to focus on video and image outputs for this talk.
-I'm just going to focus on language models.
+  This mimics a very basic version of how humans reason. It's similar to the OODA loop (Observe, Orient, Decide, Act).
 
-Deepfakes are a problem, but I’m all full up on problems.
-Someone else is going to have to do that talk.
+  </div>
+  <div data-slide="46">
 
-</TalkSlide>
+  Recently, people have taken this idea further and developed what are being called “generative agents”.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_45.jpeg">
+  Just over two weeks ago, this paper **"[Generative Agents](https://arxiv.org/abs/2304.03442): Interactive Simulacra of Human Behavior"** came out outlining an experiment where they made a sim-like game (as in, The Sims) filled with little people, each controlled by a language-model agent.
 
-By now language models have been turned into lots of easy-to-use products. You don't need any understanding of models or technical skills to use them. They come baked-into many existing popular tools like Photoshop or Notion.
+  </div>
+  <div data-slide="47">
 
-</TalkSlide>
+  These language-model-powered sims had some key features, such as a long-term memory database they could read and write to, the ability to reflect on their experiences, planning what to do next, and interacting with other sim agents in the game.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_46.jpeg">
+  </div>
+  <div data-slide="48">
 
-The product category that concerns me most is content generators. These are tools designed for marketers and SEO strategists to easily create publishable content.
+  And this architecture produced very compelling and believable human behaviours.
 
-I'm going to pick on one called [Blaze](https://www.blaze.ai/) but there are plenty of other tools that do the same thing.
+  The agents would perform everyday tasks such as cooking breakfast, stopping if something is burning, chatting to one another, forming opinions, and reflecting on their day.
 
-They tend to work like this: You type in what you want to write about. I’ve said "why plant-based meat is morally wrong" here. This isn't an opinion I agree with but it sounds like a good topic for clickbait.
+  Additionally, these agents exhibited more emergent social behaviours, such as planning and attending a Valentine's Day party and asking each other out on dates.
 
-</TalkSlide>
+  There's a new library called [AgentGPT](https://agentgpt.reworkd.ai/) that's making it easier to build these kind of agents. It's not as sophisticated as the sim character version, but follows the same idea of autonomous agents with memory, reflection, and tools available. It's now relatively easy to spin up similar agents that can interact with the web.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_48.jpeg">
+  </div>
+  <div data-slide="49">
 
-So I’ll have this model write an article for me.
+  I think we’re about to enter a stage of sharing the web with lots of non-human agents that are very different to our current bots – they have a lot more data on how behave like realistic humans and are rapidly going to get more and more capable.
 
-And then it churns out 700 words on it.
-This is now ready for me to publish.
+  Soon we won’t be able to tell the difference between generative agents and real humans on the web.
 
-Which if I’m someone lobbying against carbon credits is handy.
+  Sharing the web with agents isn’t inherently bad and could have good use cases such as automated moderators and search assistants, but it’s going to get complicated.
 
-I can generate 100 of these, optimise them for Google search terms, and shove them on the web.
+  </div>
+  <div data-slide="50">
 
-A hard day’s advocacy done!
+  Now, why is this a problem?
 
-The quality and truthfulness of this is clearly questionable, but we’ll get to the problems with it later.
+  I’m only going to focus on how this will be a problem for human relationships and information over the web.
 
-The point is this is very easy to do.
+  Anything else – like how we might all end up unemployed or dead soon – is beyond my pay grade.
 
-This isn't limited to blog posts and articles.
-Any text that can be generated will.
+  </div>
+  <div data-slide="51">
 
-They give you an array of convenient formats.
-Like presenting yourself on a dating site and wedding vows.
-Or “sharing tips and knowledge”. Though clearly not based off anything you’ve actually learned.
+  The cost of creating and publishing content on the web just dropped to almost zero.
 
-</TalkSlide>
+  Humans are expensive and slow at making content. We need time to research, read, think, and clumsily string words together. And then we insist on taking more time to eat, sleep, socialise, and shower.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_51.jpeg">
+  Generative models, on the other hand, write much faster, don't need time off, and don't get bored.
 
-There’s every manifestation of this; Tweet generators, Linked In post generators, turn YouTube videos into tweets and vice versa.
+  ChatGPT currently costs a fraction of a cent ($0.002) to generate 1000 tokens (~words), meaning that it would cost only two cents to generate 100 articles of 1000 words. If we used a more sophisticated architecture like prompt chaining the cost would certainly be higher, but still affordable.
 
-You're able to reuse content quite easily. This is all a marketer's dream!
+  Given that these creations are cheap, easy to use, fast, and can produce a nearly infinite amount of content...
 
-</TalkSlide>
+  </div>
+  <div data-slide="52">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_52.jpeg">
+  ...I think we’re about to drown in a sea of informational garbage.
 
-Most of the tools and examples I’ve shown so far have a fairly simple architecture.
+  We’re going to be _absolutely swamped_ by masses of mediocre content.
 
-They’re made by feeding a single input, or prompt, into the big black mystery box of a language model. (We call them black boxes because we don't know that much about how they reason or produce answers. It's a mystery to everyone, including their creators.)
+  Every marketer, SEO strategist, and optimiser bro is going to have a field day
+  filling Twitter and Facebook and Linked In and Google search results
+  with masses of keyword-stuffed, optimised, generated crap.
 
-And we get a single output – an image, some text, or an article.
+  This explosion of noise will make it difficult to hear any signal. We'll need to find more robust ways to filter our feeds and curate good-quality work.
 
-</TalkSlide>
+  While we already have tools to deal with spam and filter low-quality content, I think this new, more sophisticated of junk will leak through. I expect it will take a few years to get our content moderation, filtering, and defence systems to catch up.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_53.jpeg">
+  Meta note: This image was made in Midjourney. It's the only AI-generated image I’m using in this talk. I mostly wanted to show that AI can do hands now – progress!
 
-We can scale that up to many outputs.
+  </div>
+  <div data-slide="53">
 
-Most companies that make language models have an API you can hit. So we can ask for 1,000 or 100,000 articles.
+  We can tell this is already happening because spammers and scammers are lazy as fuck.
 
-But we’re still limited in how sophisticated we can get with these outputs.
+  This recent Verge article: **"'[As an Al language model](https://www.theverge.com/2023/4/25/23697218/ai-generated-spam-fake-user-reviews-as-an-ai-language-model)': the phrase that shows how Al is polluting the web"** pointed out that the phrase “as an AI language model” is showing up in all kinds of places: Amazon reviews, Yelp reviews, Tweets, and LinkedIn posts.
 
-</TalkSlide>
+  This is a common phrase that shows up in ChatGPT outputs. As in “as an AI language model, I do not have any political opinions”
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_54.jpeg">
+  The fact spammers couldn’t even be bothered to remove this obvious giveaway from their outputs shows the level of care and detail they’ll put into future work.
 
-Recently, people have been developing more sophisticated methods of prompting language models, such as "prompt chaining" or composition.
+  </div>
+  <div data-slide="54">
 
-Ought has been [researching this](https://ought.org/research/factored-cognition) for a few years. Recently released libraries like [LangChain](https://python.langchain.com/en/latest/) make it much easier to do.
+  Last week a NewsGuard report came out detailing how they found 49 entirely AI generated but legitimate looking “news” websites, all publishing misinformation that ranks well on Google
 
-This approach solves many of the weaknesses of language models, such as a lack of knowledge of recent events, inaccuracy, difficulty with mathematics, lack of long-term memory, and their inability to interact with the rest of our digital systems.
+  </div>
+  <div data-slide="55">
 
-Prompt chaining is a way of setting up a language model to mimic a reasoning loop in combination with external tools.
+  There’s been a surge in self-published books on Amazon…
 
-You give it a goal to achieve, and then the model loops through a set of steps: it observes and reflects on what it knows so far and then decides on a course of action. It can pick from a set of tools to help solve the problem, such as searching the web, writing and running code, querying a database, using a calculator, hitting an API, connecting to Zapier or IFTTT, etc.
+  </div>
+  <div data-slide="56">
 
-After each action, the model reflects on what it's learned and then picks another action, continuing the loop until it arrives at the final output.
+  The New York Times did a report on how the travel guidebook category was being flooded with generated crap.
 
-This gives us much more sophisticated answers than a single language model call, making them more accurate and able to do more complex tasks.
+  The book content scored highly on their generative AI dectectors, and the authors were made up people with generated profile images.
 
-This mimics a very basic version of how humans reason. It's similar to the OODA loop (Observe, Orient, Decide, Act).
+  Amazon has started limiting the number of self-published books to 3 a day in response.
 
-</TalkSlide>
+  </div>
+  <div data-slide="57">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_55.jpeg">
+  The tell-tale phrase “as an AI language model” shows up all the time in Amazon reviews, Yelp reviews, Tweets, and LinkedIn posts.
 
-Recently, people have taken this idea further and developed what are being called “generative agents”.
+  </div>
+  <div data-slide="58">
 
-Just over two weeks ago, this paper **"[Generative Agents](https://arxiv.org/abs/2304.03442): Interactive Simulacra of Human Behavior"** came out outlining an experiment where they made a sim-like game (as in, The Sims) filled with little people, each controlled by a language-model agent.
+  Most are very boring attempts to get ChatGPT to write engaging LinkedIn posts
 
-</TalkSlide>
+  </div>
+  <div data-slide="59">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_56.jpeg">
+  One of my favorite Twitter accounts at the moment is dead internet at its finest which collects examples of generated crap
 
-These language-model-powered sims had some key features, such as a long-term memory database they could read and write to, the ability to reflect on their experiences, planning what to do next, and interacting with other sim agents in the game.
+  </div>
+  <div data-slide="60">
 
-</TalkSlide>
+  Reply sections like this Bots replying en mass to content with: “Incredible graphics, engaging storyline, immersive.” “Congratulations on your remarkable success.”
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_57.jpeg">
+  </div>
+  <div data-slide="61">
 
-And this architecture produced very compelling and believable human behaviours.
+  Facebook is a whole different story. I hadn’t been on in about a decade. Found [a paper](https://fsi9-prod.s3.us-west-1.amazonaws.com/s3fs-public/2024-03/DiRestaGoldstein_AIGeneratedImages_Preprint.pdf) published in March by two Stanford researchers looking at AI generated spam and scam images. Found hundreds of pages of generative content farms. These pictures of AI generated children all have a million engagements or more on them. Despite being obviously fake This paper sent me down a awful rabbit hole… Where I learned if there’s one thing boomers on Facebook love, it’s children making things, and Jesus.
 
-The agents would perform everyday tasks such as cooking breakfast, stopping if something is burning, chatting to one another, forming opinions, and reflecting on their day.
+  </div>
+  <div data-slide="62">
 
-Additionally, these agents exhibited more emergent social behaviours, such as planning and attending a Valentine's Day party and asking each other out on dates.
+  Here’s a generated AI child making a rather unbelievable Jesus sand sculpture with 11,000 enaggaements and over 300 comments
 
-There's a new library called [AgentGPT](https://agentgpt.reworkd.ai/) that's making it easier to build these kind of agents. It's not as sophisticated as the sim character version, but follows the same idea of autonomous agents with memory, reflection, and tools available. It's now relatively easy to spin up similar agents that can interact with the web.
+  </div>
+  <div data-slide="63">
 
-</TalkSlide>
+  And another AI generated child in a slum who made a Coca-cola Jesus? Very entreprenrial of him. The spirit of capitalism alive and well here. Again, thousands of engagements, hundreds of comments
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_58.jpeg">
+  </div>
+  <div data-slide="64">
 
-I think we’re about to enter a stage of sharing the web with lots of non-human agents that are very different to our current bots – they have a lot more data on how behave like realistic humans and are rapidly going to get more and more capable.
+  And finally… I cannot explain what this is or why, but this crab Jesus has over 200,000 engagements and 4000 comments There are many other more disturbing examples I didn’t have the stomach to put in. So the examples I’m showing here are extremely unsophisticated. This is bot-generated-nonsense with bots reacting to it. We’ll probably be able to filter out and ignore the vast majority of this. I’m more worried about the more sophisticated version of this.
 
-Soon we won’t be able to tell the difference between generative agents and real humans on the web.
+  </div>
+  <div data-slide="65">
 
-Sharing the web with agents isn’t inherently bad and could have good use cases such as automated moderators and search assistants, but it’s going to get complicated.
+  Let’s look at some hypothetical scenarios of how this might unfold.
 
-</TalkSlide>
+  This is Nigel. He’s written a book on ‘Why Nepotism is Great’ and he wants to be a bookfluencer.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_59.jpeg">
+  We're going to give him the benefit of the doubt and assume he's actually written this book and not prompted it into existence.
 
-Now, why is this a problem?
+  So he spins up an agent
 
-I’m only going to focus on how this will be a problem for human relationships and information over the web.
+  And tells it to promote the book (not so different to a traditional book agent!)
 
-Anything else – like how we might all end up unemployed or dead soon – is beyond my pay grade.
+  And then gives it access to all his social media accounts via APIs or something like Zapier.
 
-</TalkSlide>
+  </div>
+  <div data-slide="66">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_60.jpeg">
+  The agent takes a moment to strategise. And then gets to work.
 
-The cost of creating and publishing content on the web just dropped to almost zero.
+  It generates and schedules a steady stream of tweets based on the book content. Then turns those into posts optimised for LinkedIn and Facebook. It then writes and schedules a newsletter every week for 6 months. Then sets up a Medium account and republishes those as articles. It moves onto creating a set of addictive TikTok videos, a 24-part series for YouTube, and generates a bunch of podcast episodes that use Nigel’s voice (trivial to do at this point). And finally finds other people writing about nepotism and starts replying to everything they publish on Twitter, LinkedIn, etc. in order to
 
-Humans are expensive and slow at making content. We need time to research, read, think, and clumsily string words together. And then we insist on taking more time to eat, sleep, socialise, and shower.
+  This is not that different to what Nigel could do.
+  And the agent knows not to make _tons_ of content, lest it set off any red flags from content moderators. So it seems plausible this all could have been Nigel's doing.
 
-Generative models, on the other hand, write much faster, don't need time off, and don't get bored.
+  Without an agent, 99% of Nigel's wouldn’t have the time, energy and motivation to do this, even if they had written a book. And they certainly couldn't keep up this consistency of output. I also expect Nigel’s agent will write quite compelling, accurate content. Perhaps better than Nigel.
 
-ChatGPT currently costs a fraction of a cent ($0.002) to generate 1000 tokens (~words), meaning that it would cost only two cents to generate 100 articles of 1000 words. If we used a more sophisticated architecture like prompt chaining the cost would certainly be higher, but still affordable.
+  </div>
+  <div data-slide="67">
 
-Given that these creations are cheap, easy to use, fast, and can produce a nearly infinite amount of content...
+  So now instead of only 1% of people having the time and energy to be prolific self-promoters.
 
-</TalkSlide>
+  </div>
+  <div data-slide="68">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_61.jpeg">
+  99% of people have the capacity to publish this mass of content to the web. It doesn't mean they will, but they _could_.
 
-...I think we’re about to drown in a sea of informational garbage.
+  Clearly, we already have lots of spam on the web now that we’re able to filter out and ignore. But I think the scale and quality of this new kind is something we’re not prepared for.
 
-We’re going to be _absolutely swamped_ by masses of mediocre content.
+  Now imagine how this plays out with a political group with a specific agenda to push...
 
-Every marketer, SEO strategist, and optimiser bro is going to have a field day
-filling Twitter and Facebook and Linked In and Google search results
-with masses of keyword-stuffed, optimised, generated crap.
+  </div>
+  <div data-slide="69">
 
-This explosion of noise will make it difficult to hear any signal. We'll need to find more robust ways to filter our feeds and curate good-quality work.
+  So here's Genetic Guardians – they're a bunch of political lobbyists who strongly believe in gene editing. And want to spread the good word.
 
-While we already have tools to deal with spam and filter low-quality content, I think this new, more sophisticated of junk will leak through. I expect it will take a few years to get our content moderation, filtering, and defence systems to catch up.
+  But they understand scale in a way Nigel doesn’t.
 
-Meta note: This image was made in Midjourney. It's the only AI-generated image I’m using in this talk. I mostly wanted to show that AI can do hands now – progress!
+  </div>
+  <div data-slide="70">
 
-</TalkSlide>
+  They spin up 1000 agents.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62.jpeg">
+  And tell each of them to go be influencers. They should appear to be real, consistent people who have accounts on most major social media platforms. They have their own websites and Twitter accounts. And they behave just like the other humans on the web.
 
-We can tell this is already happening because spammers and scammers are lazy as fuck.
+  But each influencer is a one-person media machine making engaging and educational content about gene editing. They publish books. They make mini-docs on YouTube. They host each other on their podcasts.
 
-This recent Verge article: **"'[As an Al language model](https://www.theverge.com/2023/4/25/23697218/ai-generated-spam-fake-user-reviews-as-an-ai-language-model)': the phrase that shows how Al is polluting the web"** pointed out that the phrase “as an AI language model” is showing up in all kinds of places: Amazon reviews, Yelp reviews, Tweets, and LinkedIn posts.
+  They essentially build an influencer content ring around gene editing.
 
-This is a common phrase that shows up in ChatGPT outputs. As in “as an AI language model, I do not have any political opinions”
+  And they still don’t set off any suspicions of being bots or content moderation flags. Individually, they all appear to make a reasonable, human amount of content.
 
-The fact spammers couldn’t even be bothered to remove this obvious giveaway from their outputs shows the level of care and detail they’ll put into future work.
+  This is almost doable right now. It would certainly be a bit expensive to do at this scale. But we should expect costs to drop and there are some well-funded lobbying groups out there. I wouldn't be surprised if it's already happening.
 
-</TalkSlide>
+  </div>
+  <div data-slide="71">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 2.jpeg">
+  I have some good news though.
 
-Last week a NewsGuard report came out detailing how they found 49 entirely AI generated but legitimate looking “news” websites, all publishing misinformation that ranks well on Google
+  This has all been a bit dark. Let's take a breath.
 
-</TalkSlide>
+  </div>
+  <div data-slide="72">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 3.jpeg">
+  This might not be a problem.
 
-There’s been a surge in self-published books on Amazon…
+  This is only a problem if...
 
-</TalkSlide>
+  </div>
+  <div data-slide="73">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 4.jpeg">
+  ...we want to use the web for very particular purposes.
 
-The New York Times did a report on how the travel guidebook category was being flooded with generated crap.
+  Such as facilitating genuine human connections, pursuing collective sense-making and building knowledge together, and ideally grounding our knowledge of the world in reality.
 
-The book content scored highly on their generative AI dectectors, and the authors were made up people with generated profile images.
+  So, if you don't care about these things, don't worry about generative AI!
+  Everything will be fine!
 
-Amazon has started limiting the number of self-published books to 3 a day in response.
+  We're about to have much more engaging content on social media. TikTok will be lit.
 
-</TalkSlide>
+  However, I'm quite keen on these outcomes; I write on the web a lot, I'm a big proponent of people publishing personal knowledge online, and I encourage everyone to do it.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 5.jpeg">
+  I keep banging on about digital gardening which is essentially having your own personal wiki on the web.
 
-The tell-tale phrase “as an AI language model” shows up all the time in Amazon reviews, Yelp reviews, Tweets, and LinkedIn posts.
+  The goal here is to make the web a space for collective understanding and knowledge-building, something lots of other speakers here have touched on. Which requires that we're able to find, share, and curate high-quality, reliable, and insightful information.
 
-</TalkSlide>
+  I'm worried that generative agents threaten that, at least in the short term.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 6.jpeg">
+  </div>
+  <div data-slide="74">
 
-Most are very boring attempts to get ChatGPT to write engaging LinkedIn posts
+  When I talk to people about my worries, I always get this question:
 
-</TalkSlide>
+  **Why does it matter if a generative model made something rather than a human?**
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 7.jpeg">
+  In most cases, language models are more accurate and knowledgeable than most humans.
+  Benchmarks have shown this. At least when it comes to referencing well-documented facts. They’re frankly better writers than a lot of us.
 
-One of my favorite Twitter accounts at the moment is dead internet at its finest which collects examples of generated crap
+  Surely, having more generated content on the web would make it a more reliable and valuable place for all of us?
 
-</TalkSlide>
+  And I’m sympathetic to this point...
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 8.jpeg">
+  </div>
+  <div data-slide="75">
 
-Reply sections like this Bots replying en mass to content with: “Incredible graphics, engaging storyline, immersive.” “Congratulations on your remarkable success.”
+  But there are a few key differences between content generated by models versus content made by humans.
 
-</TalkSlide>
+  First is its connection to reality.
+  Second, the social context they live within.
+  And finally their potential for human relationships.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 9.jpeg">
+  </div>
+  <div data-slide="76">
 
-Facebook is a whole different story. I hadn’t been on in about a decade. Found [a paper](https://fsi9-prod.s3.us-west-1.amazonaws.com/s3fs-public/2024-03/DiRestaGoldstein_AIGeneratedImages_Preprint.pdf) published in March by two Stanford researchers looking at AI generated spam and scam images. Found hundreds of pages of generative content farms. These pictures of AI generated children all have a million engagements or more on them. Despite being obviously fake This paper sent me down a awful rabbit hole… Where I learned if there’s one thing boomers on Facebook love, it’s children making things, and Jesus.
+  First, generated content is different because it has a different relationship to reality than us.
 
-</TalkSlide>
+  </div>
+  <div data-slide="77">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 10.jpeg">
+  We are embodied humans in a shared reality filled with rich embodied sensory information.
 
-Here’s a generated AI child making a rather unbelievable Jesus sand sculpture with 11,000 enaggaements and over 300 comments
+  When we read, we compare other people's accounts of reality against our own experiences. We question whether their views align with ours. And then we write our own accounts.
 
-</TalkSlide>
+  In doing this, we are all participating in this beautiful cycle of trying to make sense of everything together. This is the core of all science, art, and literature. We are trying to understand and teach each other things through writing.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 11.jpeg">
+  We have now fed this enormous written record into large language models, encoding a bunch of patterns in their networks, creating a representation of the existing written knowledge of humanity.
 
-And another AI generated child in a slum who made a Coca-cola Jesus? Very entreprenrial of him. The spirit of capitalism alive and well here. Again, thousands of engagements, hundreds of comments
+  This model can now generate text that is predictably similar to all the text it has seen before.
 
-</TalkSlide>
+  But the tricky bit is trying to figure out how much this generated text relates to reality.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_62 12.jpeg">
+  </div>
+  <div data-slide="78">
 
-And finally… I cannot explain what this is or why, but this crab Jesus has over 200,000 engagements and 4000 comments There are many other more disturbing examples I didn’t have the stomach to put in. So the examples I’m showing here are extremely unsophisticated. This is bot-generated-nonsense with bots reacting to it. We’ll probably be able to filter out and ignore the vast majority of this. I’m more worried about the more sophisticated version of this.
+  In some sense, it’s fully _UNHINGED_.
 
-</TalkSlide>
+  The model cannot check its claims against reality because it can’t access reality.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_63.jpeg">
+  But it’s a bit like a fuzzy memory of reality.
 
-Let’s look at some hypothetical scenarios of how this might unfold.
+  It _is_ based off what we’ve written about the world, but can’t validate its claims.
 
-This is Nigel. He’s written a book on ‘Why Nepotism is Great’ and he wants to be a bookfluencer.
+  </div>
+  <div data-slide="79">
 
-We're going to give him the benefit of the doubt and assume he's actually written this book and not prompted it into existence.
+  We politely call it “hallucination” when language models say things that don’t reflect reality.
 
-So he spins up an agent
+  In ways, it’s like a terribly smart person on some mild drugs. They're confused about who they are and where they are, but they're still super knowledgeable.
 
-And tells it to promote the book (not so different to a traditional book agent!)
+  This disconnect between its superhuman intelligence and incompetence is one of the hardest things to reconcile.
 
-And then gives it access to all his social media accounts via APIs or something like Zapier.
+  </div>
+  <div data-slide="80">
 
-</TalkSlide>
+  A big part of this limitation is that these models only deal with language.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_64.jpeg">
+  And language is only one small part of how a human understands and processes the world.
 
-The agent takes a moment to strategise. And then gets to work.
+  We perceive and reason and interact with the world via spatial reasoning, embodiment, sense of time, touch, taste, memory, vision, and sound.
+  These are all pre-linguistic. And they live in an entirely separate part of the brain from language.
 
-It generates and schedules a steady stream of tweets based on the book content. Then turns those into posts optimised for LinkedIn and Facebook. It then writes and schedules a newsletter every week for 6 months. Then sets up a Medium account and republishes those as articles. It moves onto creating a set of addictive TikTok videos, a 24-part series for YouTube, and generates a bunch of podcast episodes that use Nigel’s voice (trivial to do at this point). And finally finds other people writing about nepotism and starts replying to everything they publish on Twitter, LinkedIn, etc. in order to
+  Generating text strings is not the end-all be-all of what it means to be intelligent or human.
 
-This is not that different to what Nigel could do.
-And the agent knows not to make _tons_ of content, lest it set off any red flags from content moderators. So it seems plausible this all could have been Nigel's doing.
+  So simulated humans that can only deal with language are missing a big part of what we perceive as human “reality.”
 
-Without an agent, 99% of Nigel's wouldn’t have the time, energy and motivation to do this, even if they had written a book. And they certainly couldn't keep up this consistency of output. I also expect Nigel’s agent will write quite compelling, accurate content. Perhaps better than Nigel.
+  </div>
+  <div data-slide="81">
 
-</TalkSlide>
+  Language models are also different in their social context.
+  In that they have a strange relationship to our social world.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_65.jpeg">
+  Everything we say is situated in a social context.
+  I'm assuming everyone in this room has an usually high level of technical literacy. I don’t talk to my writer friends, or my aunt in the same way I'm going to talk to you.
+  We are always evaluating the amount of shared context we have with people we're talking to - it changes how we communicate.
 
-So now instead of only 1% of people having the time and energy to be prolific self-promoters.
+  If I met someone from Shakespearean England, we’d have some trouble communicating because we share less context. We don't just speak in different dialects, we have different morals and values, we have different assumptions about how society works and how science works.
 
-</TalkSlide>
+  The point is there is no truth or knowledge outside of social context. Everything we say is contextual and relies on a shared social world.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_66.jpeg">
+  But a language model is not a person with a fixed identity.
 
-99% of people have the capacity to publish this mass of content to the web. It doesn't mean they will, but they _could_.
+  They know nothing about the cultural context of who they’re talking to.
+  They take on different characters depending on how you prompt them and don’t hold fixed opinions.
+  They are not speaking from one stable social position.
 
-Clearly, we already have lots of spam on the web now that we’re able to filter out and ignore. But I think the scale and quality of this new kind is something we’re not prepared for.
+  This leads some people to claim they’re objective or more reliable than humans with biases.
 
-Now imagine how this plays out with a political group with a specific agenda to push...
+  </div>
+  <div data-slide="82">
 
-</TalkSlide>
+  But they in fact _do_ represent a very particular way of seeing the world.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_67.jpeg">
+  We trained them primarily on text scraped from the web. They're of course also trained on books and Wikipedia, but it's a far smaller percentage of the training data.
 
-So here's Genetic Guardians – they're a bunch of political lobbyists who strongly believe in gene editing. And want to spread the good word.
+  This means they primarily represent the generalised views of a majority English-speaking, western population who have written a lot on Reddit and lived between about 1900 and 2023.
 
-But they understand scale in a way Nigel doesn’t.
+  Which in the grand scheme of history and geography, is an _incredibly_ narrow slice of humanity.
 
-</TalkSlide>
+  This clearly does not represent all human cultures and languages and ways of being.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_68.jpeg">
+  We are taking an already dominant way of seeing the world and generating even more content reinforcing that dominance.
 
-They spin up 1000 agents.
+  We don’t have enough data from people who have lived in different historical periods or minority cultures with less written content to represent them in current models.
 
-And tell each of them to go be influencers. They should appear to be real, consistent people who have accounts on most major social media platforms. They have their own websites and Twitter accounts. And they behave just like the other humans on the web.
+  This hopefully improves with time, but it's hard to solve with limited data.
 
-But each influencer is a one-person media machine making engaging and educational content about gene editing. They publish books. They make mini-docs on YouTube. They host each other on their podcasts.
+  </div>
+  <div data-slide="83">
 
-They essentially build an influencer content ring around gene editing.
+  If I put my anthropologist hat on and look at this problem it feels exceptionally tragic.
 
-And they still don’t set off any suspicions of being bots or content moderation flags. Individually, they all appear to make a reasonable, human amount of content.
+  Our entire discipline tries to expand the collective understanding of how diverse human cultures can be. We try to help people realise both how unified we are as a species, but also how flexible and adaptable human cultures can be – far weirder and more wonderful than we can imagine.
 
-This is almost doable right now. It would certainly be a bit expensive to do at this scale. But we should expect costs to drop and there are some well-funded lobbying groups out there. I wouldn't be surprised if it's already happening.
+  This is captured well in this quote from Tim Ingold, a well-known and brilliant anthropologist: “Every way of life represents a communal experiment in living. The world itself is never settled in its structure and composition. It is continually coming into being.”
 
-</TalkSlide>
+  Generating a mass of content from a very particular way of viewing the world funnels us down into a monoculture. Which feels like shutting down a ton of possibilities and diversity for all the ways human culture might unfold in the future.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_69.jpeg">
+  Not to mention all the existing cultures and languages we might lose in this process.
 
-I have some good news though.
+  </div>
+  <div data-slide="84">
 
-This has all been a bit dark. Let's take a breath.
+  Lastly, generated content lacks any potential for human relationships.
 
-</TalkSlide>
+  When you read someone else’s writing online, it’s an invitation to connect with them. You can reply to their work, direct message them, meet for coffee or a drink, and ideally become friends or intellectual sparring partners. I’ve had this happen with so many people. Highly recommend.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_70.jpeg">
+  There is always someone on the other side of the work who you can have a full human relationship with.
 
-This might not be a problem.
+  Some of us might argue this is the whole point of writing on the web.
 
-This is only a problem if...
+  </div>
+  <div data-slide="85">
 
-</TalkSlide>
+  This isn't the case with generated writing.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_71.jpeg">
+  This is a still from the film ‘Her’ which is now the canonical reference for para-social relationships with AIs.
 
-...we want to use the web for very particular purposes.
+  In it, Joaquin Phoenix has a wonderful relationship with his personal AI. He talks to her via an earpiece all day, grows increasingly distant from the humans around him, and eventually falls in love. The AI then grows bored of him and his tiny human mind and leaves.
 
-Such as facilitating genuine human connections, pursuing collective sense-making and building knowledge together, and ideally grounding our knowledge of the world in reality.
+  This is a good lesson about the potentially unfulfilling outcomes we face if we try to form emotional relationships with AI.
 
-So, if you don't care about these things, don't worry about generative AI!
-Everything will be fine!
+  But _some_ people took this as a suggestion rather than a dark premonition...
 
-We're about to have much more engaging content on social media. TikTok will be lit.
+  </div>
+  <div data-slide="86">
 
-However, I'm quite keen on these outcomes; I write on the web a lot, I'm a big proponent of people publishing personal knowledge online, and I encourage everyone to do it.
+  This is [Replika](https://replika.ai/), a real service that creates an “AI companion” for you. Here agents are being used to create faux friends or romantic partners.
 
-I keep banging on about digital gardening which is essentially having your own personal wiki on the web.
+  _Obviously_, generative models cannot fulfill all the needs humans have in relationships. They cannot hug you, come to your birthday party, truly empathise with your situation, or tell you about their experiences grounded in the real world.
 
-The goal here is to make the web a space for collective understanding and knowledge-building, something lots of other speakers here have touched on. Which requires that we're able to find, share, and curate high-quality, reliable, and insightful information.
+  In the same way generated content can’t facilitate real, fulfilling human relationships.
 
-I'm worried that generative agents threaten that, at least in the short term.
+  </div>
+  <div data-slide="87">
 
-</TalkSlide>
+  So that all sounds quite bad. Let's do some more deep breaths.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_72.jpeg">
+  I now want to talk about possible futures.
 
-When I talk to people about my worries, I always get this question:
+  This is going to be a non-comprehensive, not mutually exclusive list of themes and trends. I'm guessing many of these will happen in parallel over the next 5 years. I'm not dumb enough to predict any further out than that.
 
-**Why does it matter if a generative model made something rather than a human?**
+  </div>
+  <div data-slide="88">
 
-In most cases, language models are more accurate and knowledgeable than most humans.
-Benchmarks have shown this. At least when it comes to referencing well-documented facts. They’re frankly better writers than a lot of us.
+  First, we’re all about to spend a lot of time thinking about how to pass the reverse Turing test.
 
-Surely, having more generated content on the web would make it a more reliable and valuable place for all of us?
+  A lot of this talk is based on an essay called the [[The Dark Forest and Generative AI]] I wrote back in January. So roughly 5 years ago in AI development time.
 
-And I’m sympathetic to this point...
+  In it, I focused a lot on this question of how we might prove we’re human on a web filled with fairly sophisticated generated content and agents. I still think this is a relevant short-term concern.
 
-</TalkSlide>
+  </div>
+  <div data-slide="89">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_73.jpeg">
+  The original Turing test had a human talk to a computer and another human through only text messages.
 
-But there are a few key differences between content generated by models versus content made by humans.
+  If the computer seemed plausibly human, it passed the test.
 
-First is its connection to reality.
-Second, the social context they live within.
-And finally their potential for human relationships.
+  In the original, the computer is the one who has to prove competency.
 
-</TalkSlide>
+  </div>
+  <div data-slide="90">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_74.jpeg">
+  On the new web, we’re the ones under scrutiny. Everyone is assumed to be a model until they can prove they're human.
 
-First, generated content is different because it has a different relationship to reality than us.
+  This is going to be challenging on a web flooded with sophisticated agents.
 
-</TalkSlide>
+  In the short term, we can employ a bunch of tricks like using unusual jargon and insider terminology that language models won't know yet.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_75.jpeg">
+  We can write in non-dominant languages that the models don’t have as much training data for, such as Welsh or Catalan (requires knowing one of these languages).
 
-We are embodied humans in a shared reality filled with rich embodied sensory information.
+  We can publish multi-modal work that covers both text and audio and video. This defence will probably only last another 6-12 months.
 
-When we read, we compare other people's accounts of reality against our own experiences. We question whether their views align with ours. And then we write our own accounts.
+  And lastly, we can push ourselves to do higher quality writing, research, and critical thinking. At the moment models still can't do sophisticated long-form writing full of legitimate citations and original insights.
 
-In doing this, we are all participating in this beautiful cycle of trying to make sense of everything together. This is the core of all science, art, and literature. We are trying to understand and teach each other things through writing.
+  </div>
+  <div data-slide="91">
 
-We have now fed this enormous written record into large language models, encoding a bunch of patterns in their networks, creating a representation of the existing written knowledge of humanity.
+  Related to this, I think we're about to have _much_ higher standard for humans. Models take over more mundane cognitive tasks and simpler writing.
 
-This model can now generate text that is predictably similar to all the text it has seen before.
+  We’ll demand more from human writers because great automated writing is cheap and prolific.
 
-But the tricky bit is trying to figure out how much this generated text relates to reality.
+  This raises both the floor and the ceiling for the quality of writing.
 
-</TalkSlide>
+  </div>
+  <div data-slide="92">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_76.jpeg">
+  At the moment there’s some equal distribution of exceptional, mediocre, and terrible writers on the web.
 
-In some sense, it’s fully _UNHINGED_.
+  Most of us are mediocre.
 
-The model cannot check its claims against reality because it can’t access reality.
+  First, language models will raise the floor….
 
-But it’s a bit like a fuzzy memory of reality.
+  </div>
+  <div data-slide="93">
 
-It _is_ based off what we’ve written about the world, but can’t validate its claims.
+  They're useful for people who struggle to write because of their education level or because they’re writing in a second language.
 
-</TalkSlide>
+  These people’s work will improve.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_77.jpeg">
+  Then I think there’s going to be some dual action for people with either mediocre or exceptional work.
 
-We politely call it “hallucination” when language models say things that don’t reflect reality.
+  </div>
+  <div data-slide="94">
 
-In ways, it’s like a terribly smart person on some mild drugs. They're confused about who they are and where they are, but they're still super knowledgeable.
+  Some of these people will become even more mediocre. They will try to outsource too much cognitive work to the language model and end up replacing their critical thinking and insights with boring, predictable work. Because that’s exactly the kind of writing language models are trained to do, by definition.
 
-This disconnect between its superhuman intelligence and incompetence is one of the hardest things to reconcile.
+  </div>
+  <div data-slide="95">
 
-</TalkSlide>
+  But some people will realise they shouldn’t be letting language models literally write words for them. Instead, they'll strategically use them as part of their process to become even better writers.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_78.jpeg">
+  They'll integrate them by using them as sounding boards while developing ideas, research helpers, organisers, debate partners, and Socratic questioners.
 
-A big part of this limitation is that these models only deal with language.
+  These people will get even better. They’ll also be pushed to do much more original, creative work in a world flooded with generic content.
 
-And language is only one small part of how a human understands and processes the world.
+  </div>
+  <div data-slide="96">
 
-We perceive and reason and interact with the world via spatial reasoning, embodiment, sense of time, touch, taste, memory, vision, and sound.
-These are all pre-linguistic. And they live in an entirely separate part of the brain from language.
+  I apologise for this phrase, but it too perfectly captures the point I'm trying to make. I polled people on whether to use it and ended up with a 50/50 split. So I went for it.
 
-Generating text strings is not the end-all be-all of what it means to be intelligent or human.
+  Anyway, we’re about to enter a phase of human centipede epistemology. Please don’t ask me to explain that, you can google it later.
 
-So simulated humans that can only deal with language are missing a big part of what we perceive as human “reality.”
+  The point is that if content generated from models becomes our source of truth,
+  the way we know things is simply that a language model once said them. Then they're forever captured in the circular flow of generated information.
 
-</TalkSlide>
+  </div>
+  <div data-slide="97">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_79.jpeg">
+  So instead of our current model where the training data is at least based on real-world experience...
 
-Language models are also different in their social context.
-In that they have a strange relationship to our social world.
+  </div>
+  <div data-slide="98">
 
-Everything we say is situated in a social context.
-I'm assuming everyone in this room has an usually high level of technical literacy. I don’t talk to my writer friends, or my aunt in the same way I'm going to talk to you.
-We are always evaluating the amount of shared context we have with people we're talking to - it changes how we communicate.
+  ...we’re going to use the text generated by these models to train new models.
+  That tenuous link to the real world becomes completely divorced from it
 
-If I met someone from Shakespearean England, we’d have some trouble communicating because we share less context. We don't just speak in different dialects, we have different morals and values, we have different assumptions about how society works and how science works.
+  This is already happening – models are still being trained on text scraped from the web, and web text is increasingly being generated.
 
-The point is there is no truth or knowledge outside of social context. Everything we say is contextual and relies on a shared social world.
+  </div>
+  <div data-slide="99">
 
-But a language model is not a person with a fixed identity.
+  One tangible risk here is the development of scientific paper mills.
 
-They know nothing about the cultural context of who they’re talking to.
-They take on different characters depending on how you prompt them and don’t hold fixed opinions.
-They are not speaking from one stable social position.
+  People may use generative models to write scientific papers that claim to find things that haven’t actually been tested. Usually, findings that benefit particular commercial or political interests.
 
-This leads some people to claim they’re objective or more reliable than humans with biases.
+  There was a study done this past December to get a sense of how possible this is:
+  **[Comparing scientific abstracts](https://www.biorxiv.org/content/10.1101/2022.12.23.521610v1) generated by ChatGPT to original abstracts using an artificial intelligence output detector, plagiarism detector, and blinded human reviewers"** – Catherine Gao, et al. (2022)
 
-</TalkSlide>
+  Blinded human reviewers were given a mix of real paper abstracts and ChatGPT-generated abstracts for submission to 5 of the highest-impact medical journals.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_80.jpeg">
+  </div>
+  <div data-slide="100">
 
-But they in fact _do_ represent a very particular way of seeing the world.
+  The reviewers spotted the ChatGPT-generated abstracts 68% of the time. Which is pretty good! But they missed 32% of them. They also incorrectly identified 14% of real abstracts as being AI-generated.
 
-We trained them primarily on text scraped from the web. They're of course also trained on books and Wikipedia, but it's a far smaller percentage of the training data.
+  We should note this was done with the GPT-3.5, which is less capable than the newer GPT-4, and didn't use any sophisticated prompt chaining techniques.
 
-This means they primarily represent the generalised views of a majority English-speaking, western population who have written a lot on Reddit and lived between about 1900 and 2023.
+  So the stats are still in our favour, but we should expect this percentage to shift.
 
-Which in the grand scheme of history and geography, is an _incredibly_ narrow slice of humanity.
+  Takes the replication crisis to a whole new level.
 
-This clearly does not represent all human cultures and languages and ways of being.
+  Just because words are published in journals does not make them true.
 
-We are taking an already dominant way of seeing the world and generating even more content reinforcing that dominance.
+  </div>
+  <div data-slide="101">
 
-We don’t have enough data from people who have lived in different historical periods or minority cultures with less written content to represent them in current models.
+  Next, we have the meatspace premium.
 
-This hopefully improves with time, but it's hard to solve with limited data.
+  We will begin to preference offline-first interactions. Or as I like to call them, meatspace interactions.
 
-</TalkSlide>
+  </div>
+  <div data-slide="102">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_81.jpeg">
+  As we start to doubt all “people” online, the only way to confirm humanity is to meet offline over coffee or a drink.
 
-If I put my anthropologist hat on and look at this problem it feels exceptionally tragic.
+  </div>
+  <div data-slide="103">
 
-Our entire discipline tries to expand the collective understanding of how diverse human cultures can be. We try to help people realise both how unified we are as a species, but also how flexible and adaptable human cultures can be – far weirder and more wonderful than we can imagine.
+  Once two people, they can confirm the humanity of everyone else they've met IRL.
+  Two people who know each of these people can confirm each other's humanity because of this trust network.
 
-This is captured well in this quote from Tim Ingold, a well-known and brilliant anthropologist: “Every way of life represents a communal experiment in living. The world itself is never settled in its structure and composition. It is continually coming into being.”
+  This has a few knock-on effects:
+  People will move back to cities and densely populated areas.
+  In-person events will become preferable.
+  Being in meatspace vs. cyberspace becomes a privilege and a premium.
 
-Generating a mass of content from a very particular way of viewing the world funnels us down into a monoculture. Which feels like shutting down a ton of possibilities and diversity for all the ways human culture might unfold in the future.
+  This disadvantages people who can’t move to urban areas with higher populations, or are unable to regularly get out and meet other people.
+  This includes people with disabilities, parents of young children, caregivers, or simply people without the material means to move to expensive cities.
 
-Not to mention all the existing cultures and languages we might lose in this process.
+  This sadly undoes a lot of the connective, equalising power of the original web.
 
-</TalkSlide>
+  </div>
+  <div data-slide="104">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_82.jpeg">
+  A natural follow-on from this is to put it on the blockchain!
+  We could create on-chain authenticity checks for human-created content on the web.
 
-Lastly, generated content lacks any potential for human relationships.
+  This means some third party verifies your humanity in real life, then assigns you a cryptographic key to sign all your online content. Everything is then linked back to your identity. Clearly not great for anonymity or pseudo-anonymity.
 
-When you read someone else’s writing online, it’s an invitation to connect with them. You can reply to their work, direct message them, meet for coffee or a drink, and ideally become friends or intellectual sparring partners. I’ve had this happen with so many people. Highly recommend.
+  I’m not a on-chain person so I don’t know the details of how this would work.
+  I know people in this audience are more interested in this area and will have thoughts.
 
-There is always someone on the other side of the work who you can have a full human relationship with.
+  </div>
+  <div data-slide="105">
 
-Some of us might argue this is the whole point of writing on the web.
+  This is already a real project called [Worldcoin](https://worldcoin.org/)
 
-</TalkSlide>
+  This scary-looking orb scans your eyeball and confirms your identity then created a unique human credential for you to use online.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_83.jpeg">
+  Funnily enough, this project is affiliated with none other than OpenAI’s Sam Altman
+  – he partially helped found it and is now on the board.
 
-This isn't the case with generated writing.
+  </div>
+  <div data-slide="106">
 
-This is a still from the film ‘Her’ which is now the canonical reference for para-social relationships with AIs.
+  I’m expecting any day now Elon will announce the new purple check on Twitter that confirms your humanity
 
-In it, Joaquin Phoenix has a wonderful relationship with his personal AI. He talks to her via an earpiece all day, grows increasingly distant from the humans around him, and eventually falls in love. The AI then grows bored of him and his tiny human mind and leaves.
+  It's only going to cost $30/month, and you don't actually need to verify anything.
+  You just check a box that says I’m human.
+  Simple is better, right?
 
-This is a good lesson about the potentially unfulfilling outcomes we face if we try to form emotional relationships with AI.
+  </div>
+  <div data-slide="107">
 
-But _some_ people took this as a suggestion rather than a dark premonition...
+  Those were all a bit negative but there is some hope in this future.
 
-</TalkSlide>
+  We can certainly fight fire with fire.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_83.1.jpeg">
+  I think it’s reasonable to assume we’ll each have a set of personal language models helping us filter and manage information on the web.
 
-This is [Replika](https://replika.ai/), a real service that creates an “AI companion” for you. Here agents are being used to create faux friends or romantic partners.
+  </div>
+  <div data-slide="108">
 
-_Obviously_, generative models cannot fulfill all the needs humans have in relationships. They cannot hug you, come to your birthday party, truly empathise with your situation, or tell you about their experiences grounded in the real world.
+  I expect these to be baked into browsers or at the OS level.
 
-In the same way generated content can’t facilitate real, fulfilling human relationships.
+  These specialised models will help us identify generated content (if possible), debunk claims, flag misinformation, hunt down sources for us, curate and suggest content, and ideally solve our discovery and search problems.
 
-</TalkSlide>
+  We will have to design this very carefully, or it'll give a whole new meaning to filter bubbles.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_84.jpeg">
+  We will eventually find it absurd that anyone would browse the “raw web” without their personal model filtering it.
 
-So that all sounds quite bad. Let's do some more deep breaths.
+  In the same way, very few of us would voluntarily browse the dark web. We’re quite sure we don’t want to know what’s on it.
 
-I now want to talk about possible futures.
+  The filtered web becomes the default.
 
-This is going to be a non-comprehensive, not mutually exclusive list of themes and trends. I'm guessing many of these will happen in parallel over the next 5 years. I'm not dumb enough to predict any further out than that.
+  </div>
+  <div data-slide="109">
 
-</TalkSlide>
+  The question I want everyone to leave with is which of these possible futures would you like to make happen? Or _not_ make happen?
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_85.jpeg">
+  We have a lot of people sprinting to build fairly shallow interfaces on top of ChatGPT. The big companies are all scrambling to figure out their “AI play”. Their employees frantically DM me asking for advice about what to build.
 
-First, we’re all about to spend a lot of time thinking about how to pass the reverse Turing test.
+  At this point I should make clear generative AI is not the destructive force here.
+  The way we’re choosing to deploy it in the world is. The product decisions that expand the dark forestness of the web are the problem.
 
-A lot of this talk is based on an essay called the [[The Dark Forest and Generative AI]] I wrote back in January. So roughly 5 years ago in AI development time.
+  So if you are working on a tool that enables people to churn out large volumes of text without fact-checking, reflection, and critical thinking. And then publish it to every platform in parallel... please god, stop.
 
-In it, I focused a lot on this question of how we might prove we’re human on a web filled with fairly sophisticated generated content and agents. I still think this is a relevant short-term concern.
+  So what should you be building instead?
 
-</TalkSlide>
+  </div>
+  <div data-slide="110">
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_86.jpeg">
+  I tried to come up with three snappy principles for building products with language models. I expect these to evolve over time, but this is my first pass
 
-The original Turing test had a human talk to a computer and another human through only text messages.
+  First, protect human agency.
+  Second, treat models as reasoning engines, not sources of truth
+  And third, augment cognitive abilities rather than replace them.
 
-If the computer seemed plausibly human, it passed the test.
+  </div>
+  <div data-slide="111">
 
-In the original, the computer is the one who has to prove competency.
+  The generative agent architecture system starts with a human prompt, but then quickly hands off to autonomous agents to make decisions. The agent does a bunch of stuff, then reports back. The locus of agency in this system is within the agent.
 
-</TalkSlide>
+  And herein lies the path to self-destruction. This is what most AI safety researchers are very worried about – that we wholesale hand off complex tasks to agents who go off the rails.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_87.jpeg">
+  </div>
+  <div data-slide="112">
 
-On the new web, we’re the ones under scrutiny. Everyone is assumed to be a model until they can prove they're human.
+  A more ideal form of this is the human and the AI agent are collaborative partners
+  doing things together. These are often called human-in-the-loop systems.
 
-This is going to be challenging on a web flooded with sophisticated agents.
+  They have very short feedback loops. Humans can closely supervise system inputs and outputs, agents have limited power, and the locus of agency remains with the human.
 
-In the short term, we can employ a bunch of tricks like using unusual jargon and insider terminology that language models won't know yet.
+  These kinds of architectures will certainly be slower, so they're not necessarily the default choice. They'll be less convenient, but safer.
 
-We can write in non-dominant languages that the models don’t have as much training data for, such as Welsh or Catalan (requires knowing one of these languages).
+  This is nice in theory, but who holds the agency in a system like this is opaque and sits on a spectrum. It's not clear how much agency is too much to hand over at any one moment.
 
-We can publish multi-modal work that covers both text and audio and video. This defence will probably only last another 6-12 months.
+  Geoffrey was just telling me yesterday there was a bunch of research done in the 90s on agency and interfaces we all need to read.
 
-And lastly, we can push ourselves to do higher quality writing, research, and critical thinking. At the moment models still can't do sophisticated long-form writing full of legitimate citations and original insights.
+  </div>
+  <div data-slide="113">
 
-</TalkSlide>
+  This ties into principle two: treat models as tiny reasoning engines, not sources of truth.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_88.jpeg">
+  At the moment we tend to treat models as oracles. We ask them to answer questions or write things that become final outputs. This is where hallucination and detachment from reality become a problem.
 
-Related to this, I think we're about to have _much_ higher standard for humans. Models take over more mundane cognitive tasks and simpler writing.
+  Models are much more interesting as very small reasoning engines trained for specific, predictable tasks.
 
-We’ll demand more from human writers because great automated writing is cheap and prolific.
+  One alternate approach is to start with our own curated datasets we trust. These could be repositories of published scientific papers, our own personal notes, or public databases like Wikipedia.
 
-This raises both the floor and the ceiling for the quality of writing.
+  We can then run many small specialised model tasks over them.
+  We can do things like:
 
-</TalkSlide>
+  - Summarise
+  - Extract structured data
+  - Find contradictions
+  - Compare and contrast
+  - Group by different variables
+  - Stage a debate
+  - Surface causal reasoning chains
+  - Generate research questions
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_89.jpeg">
+  Some of these will pull on generalised training data, but there's much less risk of wild hallucination in a scoped setting. We should also always have small, observable inputs and outputs we can check.
 
-At the moment there’s some equal distribution of exceptional, mediocre, and terrible writers on the web.
+  These outputs aren't final, publishable material. They're just interim artefacts in our thinking and research process.
 
-Most of us are mediocre.
+  Making these models smaller and more specialised would also allow us to run them on local devices instead of relying on access via large corporations.
 
-First, language models will raise the floor….
+  </div>
+  <div data-slide="114">
 
-</TalkSlide>
+  Language models are actually quite good at these specific reasoning-like tasks. We use them a lot in Ought’s products.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_90.jpeg">
+  This paper on **"[Sparks of Artificial General Intelligence](https://arxiv.org/abs/2303.12712): Early experiments with GPT-4"** out of Microsoft research a month ago shows that GPT-4 has more advanced general reasoning skills than previous models. To quote them…
 
-They're useful for people who struggle to write because of their education level or because they’re writing in a second language.
+  </div>
+  <div data-slide="115">
 
-These people’s work will improve.
+  “GPT-4 can solve novel and diﬃcult tasks that span mathematics, coding, vision, medicine, law, psychology and more, without needing any special prompting”
 
-Then I think there’s going to be some dual action for people with either mediocre or exceptional work.
+  They caveat it still made lots of mistakes and they're not claiming its proto-AGI. But it can do things that seem like they would need some primitive reasoning skills.
 
-</TalkSlide>
+  This doesn’t mean it _is_ reasoning – that's a loaded and tricky word.
+  We should still be sceptical and more research is needed, but it should make us rethink what models can be used for.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_91.jpeg">
+  </div>
+  <div data-slide="116">
 
-Some of these people will become even more mediocre. They will try to outsource too much cognitive work to the language model and end up replacing their critical thinking and insights with boring, predictable work. Because that’s exactly the kind of writing language models are trained to do, by definition.
+  Lastly, we should be augmenting our cognitive abilities rather than trying to replace them.
 
-</TalkSlide>
+  Language models are very good at some things humans are not good at, such as search and discovery, role-playing identities/characters, rapidly organising and synthesising huge amounts of data, and turning fuzzy natural language inputs into structured computational outputs.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_92.jpeg">
+  And humans are good at many things models are bad at, such as checking claims against physical reality, long-term memory and coherence, embodied knowledge, understanding social contexts, and having emotional intelligence.
 
-But some people will realise they shouldn’t be letting language models literally write words for them. Instead, they'll strategically use them as part of their process to become even better writers.
+  So we should use models to do things we can’t do, not things we’re quite good at and happy doing. We should leverage the best of both kinds of “minds.”
 
-They'll integrate them by using them as sounding boards while developing ideas, research helpers, organisers, debate partners, and Socratic questioners.
+  Talking about language models as alien minds that are very different to ours is a common metaphor in the industry. People often talk about how we've 'discovered' this new king of intelligence that we don't yet understand.
 
-These people will get even better. They’ll also be pushed to do much more original, creative work in a world flooded with generic content.
+  </div>
+  <div data-slide="117">
 
-</TalkSlide>
+  Calling them aliens always makes me think of this. Which is maybe appropriate for AI risk.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_93.jpeg">
+  </div>
+  <div data-slide="118">
 
-I apologise for this phrase, but it too perfectly captures the point I'm trying to make. I polled people on whether to use it and ended up with a 50/50 split. So I went for it.
+  But I at least like the metaphor of models being a new companion species we can work with. Kate Darling wrote a great book called [The New Breed](https://us.macmillan.com/books/9781250296115/thenewbreed) where she argues we should think of robots as animals – as a companion species who compliments our skills.
+  I think this approach easily extends to language models.
 
-Anyway, we’re about to enter a phase of human centipede epistemology. Please don’t ask me to explain that, you can google it later.
+  We can best expand and augment our cognitive capacities by respecting their unique strengths and leveraging them.
 
-The point is that if content generated from models becomes our source of truth,
-the way we know things is simply that a language model once said them. Then they're forever captured in the circular flow of generated information.
+  </div>
+  <div data-slide="119">
 
-</TalkSlide>
+  There's a good article called "[Cyborgism](https://www.lesswrong.com/posts/bxt7uCiHam4QXrQAA/cyborgism)" on this approach of blending human and AI capabilities – posted to LessWrong in February.
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_94.jpeg">
+  I don’t love LessWrong as a community but there’s occasionally some good work on there.
 
-So instead of our current model where the training data is at least based on real-world experience...
+  </div>
+  <div data-slide="120">
 
-</TalkSlide>
+  That's all I have – thank you for listening!
 
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_95.jpeg">
+  I’m on Twitter [@mappletons](https://twitter.com/mappletons)
 
-...we’re going to use the text generated by these models to train new models.
-That tenuous link to the real world becomes completely divorced from it
+  I’m sure lots of people think I’ve said at least one utterly sacrilegious and misguided thing in this talk.
 
-This is already happening – models are still being trained on text scraped from the web, and web text is increasingly being generated.
+  You can go try to main character me while Twitter is still a thing.
 
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_96.jpeg">
-
-One tangible risk here is the development of scientific paper mills.
-
-People may use generative models to write scientific papers that claim to find things that haven’t actually been tested. Usually, findings that benefit particular commercial or political interests.
-
-There was a study done this past December to get a sense of how possible this is:
-**[Comparing scientific abstracts](https://www.biorxiv.org/content/10.1101/2022.12.23.521610v1) generated by ChatGPT to original abstracts using an artificial intelligence output detector, plagiarism detector, and blinded human reviewers"** – Catherine Gao, et al. (2022)
-
-Blinded human reviewers were given a mix of real paper abstracts and ChatGPT-generated abstracts for submission to 5 of the highest-impact medical journals.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_97.jpeg">
-
-The reviewers spotted the ChatGPT-generated abstracts 68% of the time. Which is pretty good! But they missed 32% of them. They also incorrectly identified 14% of real abstracts as being AI-generated.
-
-We should note this was done with the GPT-3.5, which is less capable than the newer GPT-4, and didn't use any sophisticated prompt chaining techniques.
-
-So the stats are still in our favour, but we should expect this percentage to shift.
-
-Takes the replication crisis to a whole new level.
-
-Just because words are published in journals does not make them true.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_98.jpeg">
-
-Next, we have the meatspace premium.
-
-We will begin to preference offline-first interactions. Or as I like to call them, meatspace interactions.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_99.jpeg">
-
-As we start to doubt all “people” online, the only way to confirm humanity is to meet offline over coffee or a drink.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_100.jpeg">
-
-Once two people, they can confirm the humanity of everyone else they've met IRL.
-Two people who know each of these people can confirm each other's humanity because of this trust network.
-
-This has a few knock-on effects:
-People will move back to cities and densely populated areas.
-In-person events will become preferable.
-Being in meatspace vs. cyberspace becomes a privilege and a premium.
-
-This disadvantages people who can’t move to urban areas with higher populations, or are unable to regularly get out and meet other people.
-This includes people with disabilities, parents of young children, caregivers, or simply people without the material means to move to expensive cities.
-
-This sadly undoes a lot of the connective, equalising power of the original web.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_101.jpeg">
-
-A natural follow-on from this is to put it on the blockchain!
-We could create on-chain authenticity checks for human-created content on the web.
-
-This means some third party verifies your humanity in real life, then assigns you a cryptographic key to sign all your online content. Everything is then linked back to your identity. Clearly not great for anonymity or pseudo-anonymity.
-
-I’m not a on-chain person so I don’t know the details of how this would work.
-I know people in this audience are more interested in this area and will have thoughts.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_102.jpeg">
-
-This is already a real project called [Worldcoin](https://worldcoin.org/)
-
-This scary-looking orb scans your eyeball and confirms your identity then created a unique human credential for you to use online.
-
-Funnily enough, this project is affiliated with none other than OpenAI’s Sam Altman
-– he partially helped found it and is now on the board.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_103.jpeg">
-
-I’m expecting any day now Elon will announce the new purple check on Twitter that confirms your humanity
-
-It's only going to cost $30/month, and you don't actually need to verify anything.
-You just check a box that says I’m human.
-Simple is better, right?
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_104.jpeg">
-
-Those were all a bit negative but there is some hope in this future.
-
-We can certainly fight fire with fire.
-
-I think it’s reasonable to assume we’ll each have a set of personal language models helping us filter and manage information on the web.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_105.jpeg">
-
-I expect these to be baked into browsers or at the OS level.
-
-These specialised models will help us identify generated content (if possible), debunk claims, flag misinformation, hunt down sources for us, curate and suggest content, and ideally solve our discovery and search problems.
-
-We will have to design this very carefully, or it'll give a whole new meaning to filter bubbles.
-
-We will eventually find it absurd that anyone would browse the “raw web” without their personal model filtering it.
-
-In the same way, very few of us would voluntarily browse the dark web. We’re quite sure we don’t want to know what’s on it.
-
-The filtered web becomes the default.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_106.jpeg">
-
-The question I want everyone to leave with is which of these possible futures would you like to make happen? Or _not_ make happen?
-
-We have a lot of people sprinting to build fairly shallow interfaces on top of ChatGPT. The big companies are all scrambling to figure out their “AI play”. Their employees frantically DM me asking for advice about what to build.
-
-At this point I should make clear generative AI is not the destructive force here.
-The way we’re choosing to deploy it in the world is. The product decisions that expand the dark forestness of the web are the problem.
-
-So if you are working on a tool that enables people to churn out large volumes of text without fact-checking, reflection, and critical thinking. And then publish it to every platform in parallel... please god, stop.
-
-So what should you be building instead?
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_107.jpeg">
-
-I tried to come up with three snappy principles for building products with language models. I expect these to evolve over time, but this is my first pass
-
-First, protect human agency.
-Second, treat models as reasoning engines, not sources of truth
-And third, augment cognitive abilities rather than replace them.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_108.jpeg">
-
-The generative agent architecture system starts with a human prompt, but then quickly hands off to autonomous agents to make decisions. The agent does a bunch of stuff, then reports back. The locus of agency in this system is within the agent.
-
-And herein lies the path to self-destruction. This is what most AI safety researchers are very worried about – that we wholesale hand off complex tasks to agents who go off the rails.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_109.jpeg">
-
-A more ideal form of this is the human and the AI agent are collaborative partners
-doing things together. These are often called human-in-the-loop systems.
-
-They have very short feedback loops. Humans can closely supervise system inputs and outputs, agents have limited power, and the locus of agency remains with the human.
-
-These kinds of architectures will certainly be slower, so they're not necessarily the default choice. They'll be less convenient, but safer.
-
-This is nice in theory, but who holds the agency in a system like this is opaque and sits on a spectrum. It's not clear how much agency is too much to hand over at any one moment.
-
-Geoffrey was just telling me yesterday there was a bunch of research done in the 90s on agency and interfaces we all need to read.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_110.jpeg">
-
-This ties into principle two: treat models as tiny reasoning engines, not sources of truth.
-
-At the moment we tend to treat models as oracles. We ask them to answer questions or write things that become final outputs. This is where hallucination and detachment from reality become a problem.
-
-Models are much more interesting as very small reasoning engines trained for specific, predictable tasks.
-
-One alternate approach is to start with our own curated datasets we trust. These could be repositories of published scientific papers, our own personal notes, or public databases like Wikipedia.
-
-We can then run many small specialised model tasks over them.
-We can do things like:
-
-- Summarise
-- Extract structured data
-- Find contradictions
-- Compare and contrast
-- Group by different variables
-- Stage a debate
-- Surface causal reasoning chains
-- Generate research questions
-
-Some of these will pull on generalised training data, but there's much less risk of wild hallucination in a scoped setting. We should also always have small, observable inputs and outputs we can check.
-
-These outputs aren't final, publishable material. They're just interim artefacts in our thinking and research process.
-
-Making these models smaller and more specialised would also allow us to run them on local devices instead of relying on access via large corporations.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_111.jpeg">
-
-Language models are actually quite good at these specific reasoning-like tasks. We use them a lot in Ought’s products.
-
-This paper on **"[Sparks of Artificial General Intelligence](https://arxiv.org/abs/2303.12712): Early experiments with GPT-4"** out of Microsoft research a month ago shows that GPT-4 has more advanced general reasoning skills than previous models. To quote them…
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_112.jpeg">
-
-“GPT-4 can solve novel and diﬃcult tasks that span mathematics, coding, vision, medicine, law, psychology and more, without needing any special prompting”
-
-They caveat it still made lots of mistakes and they're not claiming its proto-AGI. But it can do things that seem like they would need some primitive reasoning skills.
-
-This doesn’t mean it _is_ reasoning – that's a loaded and tricky word.
-We should still be sceptical and more research is needed, but it should make us rethink what models can be used for.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_113.jpeg">
-
-Lastly, we should be augmenting our cognitive abilities rather than trying to replace them.
-
-Language models are very good at some things humans are not good at, such as search and discovery, role-playing identities/characters, rapidly organising and synthesising huge amounts of data, and turning fuzzy natural language inputs into structured computational outputs.
-
-And humans are good at many things models are bad at, such as checking claims against physical reality, long-term memory and coherence, embodied knowledge, understanding social contexts, and having emotional intelligence.
-
-So we should use models to do things we can’t do, not things we’re quite good at and happy doing. We should leverage the best of both kinds of “minds.”
-
-Talking about language models as alien minds that are very different to ours is a common metaphor in the industry. People often talk about how we've 'discovered' this new king of intelligence that we don't yet understand.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_114.jpeg">
-
-Calling them aliens always makes me think of this. Which is maybe appropriate for AI risk.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_115.jpeg">
-
-But I at least like the metaphor of models being a new companion species we can work with. Kate Darling wrote a great book called [The New Breed](https://us.macmillan.com/books/9781250296115/thenewbreed) where she argues we should think of robots as animals – as a companion species who compliments our skills.
-I think this approach easily extends to language models.
-
-We can best expand and augment our cognitive capacities by respecting their unique strengths and leveraging them.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_116.jpeg">
-
-There's a good article called "[Cyborgism](https://www.lesswrong.com/posts/bxt7uCiHam4QXrQAA/cyborgism)" on this approach of blending human and AI capabilities – posted to LessWrong in February.
-
-I don’t love LessWrong as a community but there’s occasionally some good work on there.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/forest-talk/dft_117.jpeg">
-
-That's all I have – thank you for listening!
-
-I’m on Twitter [@mappletons](https://twitter.com/mappletons)
-
-I’m sure lots of people think I’ve said at least one utterly sacrilegious and misguided thing in this talk.
-
-You can go try to main character me while Twitter is still a thing.
-
-</TalkSlide>
+  </div>
+</ScrollyTalkSection>

--- a/src/content/talks/home-cooked-software.mdx
+++ b/src/content/talks/home-cooked-software.mdx
@@ -20,7 +20,7 @@ growthStage: "evergreen"
 cover: "../../images/covers/talk-homecooked@2.jpeg"
 ---
 
-import TalkSlide from "../../components/mdx/TalkSlide.astro";
+import ScrollyTalkSection from "../../components/mdx/ScrollyTalkSection.astro";
 import Video from "../../components/mdx/Video.astro";
 import YearsAgo from "../../components/mdx/YearsAgo.astro";
 
@@ -40,834 +40,837 @@ For the last ~year I've been keeping a close eye on how language models capabili
 	width="1200px"
 	src="/images/posts/home-cooked-software/hcs_1.webp"
 />
+<ScrollyTalkSection images={[
+  "/images/posts/home-cooked-software/hcs_2.webp",
+  "/images/posts/home-cooked-software/hcs_3.webp",
+  "/images/posts/home-cooked-software/hcs_4.webp",
+  "/images/posts/home-cooked-software/hcs_5.webp",
+  "/images/posts/home-cooked-software/hcs_6.webp",
+  "/images/posts/home-cooked-software/hcs_7.webp",
+  "/images/posts/home-cooked-software/hcs_8.webp",
+  "/images/posts/home-cooked-software/hcs_9.webp",
+  "/images/posts/home-cooked-software/hcs_10.webp",
+  "/images/posts/home-cooked-software/hcs_11.webp",
+  "/images/posts/home-cooked-software/hcs_12.webp",
+  "/images/posts/home-cooked-software/hcs_13.webp",
+  "/images/posts/home-cooked-software/hcs_14.webp",
+  "/images/posts/home-cooked-software/hcs_15.webp",
+  "/images/posts/home-cooked-software/hcs_16.webp",
+  "/images/posts/home-cooked-software/hcs_17.webp",
+  "/images/posts/home-cooked-software/hcs_18.webp",
+  "/images/posts/home-cooked-software/hcs_19.webp",
+  "/images/posts/home-cooked-software/hcs_20.webp",
+  "/images/posts/home-cooked-software/hcs_21.webp",
+  "/images/posts/home-cooked-software/hcs_22.webp",
+  "/images/posts/home-cooked-software/hcs_23.webp",
+  "/images/posts/home-cooked-software/hcs_24.webp",
+  "/images/posts/home-cooked-software/hcs_25.webp",
+  "/images/posts/home-cooked-software/hcs_26.webp",
+  "/images/posts/home-cooked-software/hcs_27.webp",
+  "/images/posts/home-cooked-software/hcs_28.webp",
+  "/images/posts/home-cooked-software/hcs_29.webp",
+  "/images/posts/home-cooked-software/hcs_30.webp",
+  "/images/posts/home-cooked-software/hcs_31.webp",
+  "/images/posts/home-cooked-software/hcs_32.webp",
+  "/images/posts/home-cooked-software/hcs_33.webp",
+  "/images/posts/home-cooked-software/hcs_34.webp",
+  "/images/posts/home-cooked-software/hcs_35.webp",
+  "/images/posts/home-cooked-software/hcs_36.webp",
+  "/images/posts/home-cooked-software/hcs_37.webp",
+  "/images/posts/home-cooked-software/hcs_38.webp",
+  "/images/posts/home-cooked-software/hcs_39.webp",
+  "/images/posts/home-cooked-software/hcs_40.webp",
+  "/images/posts/home-cooked-software/hcs_41.webp",
+  "/images/posts/home-cooked-software/hcs_42.webp",
+  "/images/posts/home-cooked-software/hcs_43.webp",
+  "/images/posts/home-cooked-software/hcs_44.webp",
+  "/images/posts/home-cooked-software/hcs_45.webp",
+  "/images/posts/home-cooked-software/hcs_46.webp",
+  "/images/posts/home-cooked-software/hcs_47.webp",
+  "/images/posts/home-cooked-software/hcs_48.webp",
+  "/images/posts/home-cooked-software/hcs_49.webp",
+  "/images/posts/home-cooked-software/hcs_50.webp",
+  "/images/posts/home-cooked-software/hcs_51.webp",
+  "/images/posts/home-cooked-software/hcs_52.webp",
+  "/images/posts/home-cooked-software/hcs_53.webp",
+  "/images/posts/home-cooked-software/hcs_54.webp",
+  "/images/posts/home-cooked-software/hcs_55.webp",
+  "/images/posts/home-cooked-software/hcs_56.webp",
+  "/images/posts/home-cooked-software/hcs_57.webp",
+  "/images/posts/home-cooked-software/hcs_58.webp",
+  "/images/posts/home-cooked-software/hcs_59.webp",
+  "/images/posts/home-cooked-software/hcs_60.webp",
+  "/images/posts/home-cooked-software/hcs_61.webp",
+  "/images/posts/home-cooked-software/hcs_62.webp",
+  "/images/posts/home-cooked-software/hcs_63.webp",
+  "/images/posts/home-cooked-software/hcs_64.webp",
+  "/images/posts/home-cooked-software/hcs_65.webp",
+  "/images/posts/home-cooked-software/hcs_66.webp",
+  "/images/posts/home-cooked-software/hcs_67.webp",
+  "/images/posts/home-cooked-software/hcs_68.webp",
+  "/images/posts/home-cooked-software/hcs_69.webp",
+  "/images/posts/home-cooked-software/hcs_70.webp",
+  "/images/posts/home-cooked-software/hcs_71.webp",
+  "/images/posts/home-cooked-software/hcs_72.webp",
+  "/images/posts/home-cooked-software/hcs_73.webp",
+  "/images/posts/home-cooked-software/hcs_74.webp",
+  "/images/posts/home-cooked-software/hcs_75.webp",
+  "/images/posts/home-cooked-software/hcs_76.webp",
+  "/images/posts/home-cooked-software/hcs_77.webp",
+  "/images/posts/home-cooked-software/hcs_78.webp",
+  "/images/posts/home-cooked-software/hcs_79.webp",
+  "/images/posts/home-cooked-software/hcs_80.webp",
+  "/images/posts/home-cooked-software/hcs_81.webp",
+  "/images/posts/home-cooked-software/hcs_82.webp",
+  "/images/posts/home-cooked-software/hcs_83.webp",
+  "/images/posts/home-cooked-software/hcs_84.webp",
+  "/images/posts/home-cooked-software/hcs_85.webp",
+  "/images/posts/home-cooked-software/hcs_86.webp",
+  "/images/posts/home-cooked-software/hcs_87.webp",
+  "/images/posts/home-cooked-software/hcs_88.webp",
+  "/images/posts/home-cooked-software/hcs_89.webp",
+  "/images/posts/home-cooked-software/hcs_90.webp",
+]}>
+<div data-slide="0">
+
+  First, a quick intro.
+  I’m Maggie.
+  I look like this on the internet.
+  I’m a product designer at a start-up called [Elicit](https://elicit.com).
+  We use machine learning and language models to make tools for scientific researchers.
+  I’m also a mediocre developer, meaning I try to build things but they sometimes don’t work.
+
+  I write about and research lots of things in public, online including tools for thought, language model interfaces, and end-user programming.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_2.webp">
+  Some of which I want to talk to you about today.
 
-First, a quick intro.
-I’m Maggie.
-I look like this on the internet.
-I’m a product designer at a start-up called [Elicit](https://elicit.com).
-We use machine learning and language models to make tools for scientific researchers.
-I’m also a mediocre developer, meaning I try to build things but they sometimes don’t work.
+  </div>
+  <div data-slide="1">
 
-I write about and research lots of things in public, online including tools for thought, language model interfaces, and end-user programming.
+  I'm here to convince you of two things.
 
-Some of which I want to talk to you about today.
+  </div>
+  <div data-slide="2">
 
-</TalkSlide>
+  First, that language models will create a golden age of local, home-cooked software and barefoot developers.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_3.webp">
+  I’ll explain these terms in a minute.
 
-I'm here to convince you of two things.
+  </div>
+  <div data-slide="3">
 
-</TalkSlide>
+  And the second thing I want to convince you of is that the [local-first](https://www.inkandswitch.com/local-first/) community has a significant role to play in building that future golden age.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_4.webp">
+  </div>
+  <div data-slide="4">
 
-First, that language models will create a golden age of local, home-cooked software and barefoot developers.
+  And so here's what we're going to talk about:
 
-I’ll explain these terms in a minute.
+  - Local-first Beyond Local Data
+  - Home Cooked vs Industrial Software
+  - My Pitch for Barefoot Developers
+  - Why Language Model Legos Need Glue
+  - How We Can Bake Local-first Into Everything.
 
-</TalkSlide>
+  </div>
+  <div data-slide="5">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_5.webp">
+  So let's talk about local-first, beyond local data.
 
-And the second thing I want to convince you of is that the [local-first](https://www.inkandswitch.com/local-first/) community has a significant role to play in building that future golden age.
+  </div>
+  <div data-slide="6">
 
-</TalkSlide>
+  I know everyone here knows what [local-first](https://www.inkandswitch.com/local-first/) is about, but here's a quick recap for people watching who might not.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_6.webp">
+  When we talk about “local-first,” we’re primarily talking about where data lives and how it syncs to our devices.
 
-And so here's what we're going to talk about:
+  So in the old school world, before the cloud, our data and our software lived on a single machine and we had no way to collaborate. Except by throwing LAN parties.
 
-- Local-first Beyond Local Data
-- Home Cooked vs Industrial Software
-- My Pitch for Barefoot Developers
-- Why Language Model Legos Need Glue
-- How We Can Bake Local-first Into Everything.
+  We then moved to the cloud era where all the programs and all the data live in the cloud and stream to our devices via the internet.
 
-</TalkSlide>
+  And now, everyone here is trying to make a new, beautiful local-first future happen,
+  where the software and the data all live on our local machines and just use the cloud to sync between them whenever we get internet access.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_7.webp">
+  </div>
+  <div data-slide="7">
 
-So let's talk about local-first, beyond local data.
+  The existing philosophy of local-first is fantastic. I’m on board with it, I know you all are too.
 
-</TalkSlide>
+  But come expand your minds with me for a moment,
+  and imagine a more holistic vision for local software.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_8.webp">
+  What if it was about more than just databases?
 
-I know everyone here knows what [local-first](https://www.inkandswitch.com/local-first/) is about, but here's a quick recap for people watching who might not.
+  </div>
+  <div data-slide="8">
 
-When we talk about “local-first,” we’re primarily talking about where data lives and how it syncs to our devices.
+  Local traditionally means something close to your home,
+  something familiar, intimate, and trusted by you,
+  something unique to its location, and something community-oriented, as in supporting local businesses.
 
-So in the old school world, before the cloud, our data and our software lived on a single machine and we had no way to collaborate. Except by throwing LAN parties.
+  </div>
+  <div data-slide="9">
 
-We then moved to the cloud era where all the programs and all the data live in the cloud and stream to our devices via the internet.
+  So there's an interpretation of local software that means software that is built close to the home and serves the needs of the home.
 
-And now, everyone here is trying to make a new, beautiful local-first future happen,
-where the software and the data all live on our local machines and just use the cloud to sync between them whenever we get internet access.
+  It’s software someone might build
+  for themselves,
+  their family and friends,
+  their neighborhood and community.
 
-</TalkSlide>
+  It solves local problems for local people.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_9.webp">
+  This idea has been floating around with various names attached to it for the last 20 years.
 
-The existing philosophy of local-first is fantastic. I’m on board with it, I know you all are too.
+  </div>
+  <div data-slide="10">
 
-But come expand your minds with me for a moment,
-and imagine a more holistic vision for local software.
+  Clay Shirky first proposed the concept of ‘[situated software](https://gwern.net/doc/technology/2004-03-30-shirky-situatedsoftware.html)’ in <YearsAgo>2004</YearsAgo>.
 
-What if it was about more than just databases?
+  </div>
+  <div data-slide="11">
 
-</TalkSlide>
+  He defined this as software “designed in and for a particular social situation or context.”
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_10.webp">
+  He painted a vision of applications that could be used by dozens of users rather than thousands or millions. This is an absurd target population both then and now.
 
-Local traditionally means something close to your home,
-something familiar, intimate, and trusted by you,
-something unique to its location, and something community-oriented, as in supporting local businesses.
+  The dream was that communities would get very form-fit tools for their particular needs, rather than trying to adapt generic software to solve them.
 
-</TalkSlide>
+  Unfortunately, Shirky was ahead of his time – it was practically impossible to build this small-scale software in <YearsAgo>2004</YearsAgo>.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_11.webp">
+  </div>
+  <div data-slide="12">
 
-So there's an interpretation of local software that means software that is built close to the home and serves the needs of the home.
+  Sixteen years later, in <YearsAgo>2020</YearsAgo>, Robin Sloan published a blog post called “[An App Can Be a Home-Cooked Meal](https://www.robinsloan.com/notes/home-cooked-app/)” which picked up on many of the same themes.
 
-It’s software someone might build
-for themselves,
-their family and friends,
-their neighborhood and community.
+  He talked about building a tiny app for his family to send short videos to one another.
+  Only his family have access.
+  He’s not going to turn it into a start-up. It doesn’t have any commercial or market value.
 
-It solves local problems for local people.
+  He made it out of care and love for the people around him to help them solve a small problem and have enjoyable experiences together.
 
-This idea has been floating around with various names attached to it for the last 20 years.
+  Just like he would if he had made them a home-cooked meal.
 
-</TalkSlide>
+  </div>
+  <div data-slide="13">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_12.webp">
+  Home-cooked apps, like meals, are apps you make for the people you know and love.
 
-Clay Shirky first proposed the concept of ‘[situated software](https://gwern.net/doc/technology/2004-03-30-shirky-situatedsoftware.html)’ in <YearsAgo>2004</YearsAgo>.
+  We’ve progressed enough since <YearsAgo>2004</YearsAgo> that someone can make one of these on their own.
 
-</TalkSlide>
+  They’re simple – they require some skills, but not tons.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_13.webp">
+  They’re cheap or free to run – you’re not at the mercy of a corporate pricing strategy.
 
-He defined this as software “designed in and for a particular social situation or context.”
+  You control what happens to them – you control whether features are added or removed, and whether they’ll be shut down or sunset.
 
-He painted a vision of applications that could be used by dozens of users rather than thousands or millions. This is an absurd target population both then and now.
+  Private – won’t sell your data.
 
-The dream was that communities would get very form-fit tools for their particular needs, rather than trying to adapt generic software to solve them.
+  Serve your specific needs.
 
-Unfortunately, Shirky was ahead of his time – it was practically impossible to build this small-scale software in <YearsAgo>2004</YearsAgo>.
+  No financial pressure to monetize them or make a profit off them.
 
-</TalkSlide>
+  Safe – very little risk of nefarious actors or misaligned incentives.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_14.webp">
+  Made with love and care.
 
-Sixteen years later, in <YearsAgo>2020</YearsAgo>, Robin Sloan published a blog post called “[An App Can Be a Home-Cooked Meal](https://www.robinsloan.com/notes/home-cooked-app/)” which picked up on many of the same themes.
+  </div>
+  <div data-slide="14">
 
-He talked about building a tiny app for his family to send short videos to one another.
-Only his family have access.
-He’s not going to turn it into a start-up. It doesn’t have any commercial or market value.
+  I like collecting examples of these.
 
-He made it out of care and love for the people around him to help them solve a small problem and have enjoyable experiences together.
+  Here's an app to track newborn breastfeeding and diaper changes.
 
-Just like he would if he had made them a home-cooked meal.
+  Why put your baby’s bodily functions on someone else's server?
 
-</TalkSlide>
+  </div>
+  <div data-slide="15">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_15.webp">
+  Here’s one for reconciling personal finances that’s described as a mashup between Superhuman and Tinder, which sounds much more fun than standard financial software.
 
-Home-cooked apps, like meals, are apps you make for the people you know and love.
+  </div>
+  <div data-slide="16">
 
-We’ve progressed enough since <YearsAgo>2004</YearsAgo> that someone can make one of these on their own.
+  A live sales dashboard made with an old phone - a nice way to reuse hardware.
 
-They’re simple – they require some skills, but not tons.
+  </div>
+  <div data-slide="17">
 
-They’re cheap or free to run – you’re not at the mercy of a corporate pricing strategy.
+  This is one someone made for their diabetic partner.
+  The default interface on their glucose monitor wasn't giving them the critical information they needed, so they took matters into their own hands and made one that did.
 
-You control what happens to them – you control whether features are added or removed, and whether they’ll be shut down or sunset.
+  I think it's fitting that all of these examples of home-cooked apps deal with the kind of data you don't want leaving your personal home, like your children, bodily functions, health, and finances.
 
-Private – won’t sell your data.
+  </div>
+  <div data-slide="18">
 
-Serve your specific needs.
+  Robin Sloan’s post on home-cooked apps hit a nerve. It’s been a wildly popular piece endlessly passed around the programming community.
 
-No financial pressure to monetize them or make a profit off them.
+  I think this is because it pointed to many tensions we have around the way software is currently built.
 
-Safe – very little risk of nefarious actors or misaligned incentives.
+  These small-scale, personal apps...
 
-Made with love and care.
+  </div>
+  <div data-slide="19">
 
-</TalkSlide>
+  ..are drastically different from the kind of software most of us use every day, which is professionally made software.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_16.webp">
+  This is like a meal or cake made by a professional chef at a restaurant. Probably much more delicious than yours.
 
-I like collecting examples of these.
+  </div>
+  <div data-slide="20">
 
-Here's an app to track newborn breastfeeding and diaper changes.
+  But it is likely more complex, more expensive to make,
+  and requires many people with expertise.
 
-Why put your baby’s bodily functions on someone else's server?
+  You can’t control how it’s built, how long it lives for, or how much butter they put in it.
 
-</TalkSlide>
+  Has commercial interests at heart, rather than familial love and care.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_17.webp">
+  Less security and privacy – you don’t know where the data is going.
 
-Here’s one for reconciling personal finances that’s described as a mashup between Superhuman and Tinder, which sounds much more fun than standard financial software.
+  </div>
+  <div data-slide="21">
 
-</TalkSlide>
+  And professional software is the kind of software almost everyone in the world uses. It's made for masses of people, at a global scale, by huge corporations.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_18.webp">
+  </div>
+  <div data-slide="22">
 
-A live sales dashboard made with an old phone - a nice way to reuse hardware.
+  At the moment, we’re in the industrial, high-modernism age of software, where these standardized, one-size-fits-all apps are made for us by people who don’t know much about us.
 
-</TalkSlide>
+  </div>
+  <div data-slide="23">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_19.webp">
+  Primarily people working for large Californian corporations and shipping their software overseas.
 
-This is one someone made for their diabetic partner.
-The default interface on their glucose monitor wasn't giving them the critical information they needed, so they took matters into their own hands and made one that did.
+  They’re sitting in San Fransisco trying to understand our pains and problems over Zoom calls and customer support tickets.
 
-I think it's fitting that all of these examples of home-cooked apps deal with the kind of data you don't want leaving your personal home, like your children, bodily functions, health, and finances.
+  They have so little context on our lives, what problems we need solved, and what we value.
 
-</TalkSlide>
+  How could an American getting paid six figures in Mountain View understand how to identify problems and design solutions for a homemaker in Tokyo, a street seller in Turkey, or a doctor in Tunisia?
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_20.webp">
+  For the most part, they don’t. Or if they try, they do it badly.
 
-Robin Sloan’s post on home-cooked apps hit a nerve. It’s been a wildly popular piece endlessly passed around the programming community.
+  </div>
+  <div data-slide="24">
 
-I think this is because it pointed to many tensions we have around the way software is currently built.
+  My friend Kasey Klimes wrote a fantastic piece called “[When to Design for Emergence](https://newsletter.rhizomerd.com/p/when-to-design-for-emergence)” on the design dynamics of large-scale software after working on Google Maps.
 
-These small-scale, personal apps...
+  He points out that our current approach is designed to only solve the most common needs of the most number of users.
 
-</TalkSlide>
+  Anything beyond that is what we call the long tail of user needs. These are things only a few people need, but there's a nearly infinite amount of them.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_21.webp">
+  </div>
+  <div data-slide="25">
 
-..are drastically different from the kind of software most of us use every day, which is professionally made software.
+  In the case of Google Maps, the long tail of user needs is anything beyond "how do I get from here to there?”
 
-This is like a meal or cake made by a professional chef at a restaurant. Probably much more delicious than yours.
+  Google Maps is never going to support showing historical borders or tidal patterns, even if those things are essential to a few dozen, or even a few hundred people.
 
-</TalkSlide>
+  </div>
+  <div data-slide="26">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_22.webp">
+  In the current system, this stuff is always considered out of scope.
 
-But it is likely more complex, more expensive to make,
-and requires many people with expertise.
+  Because it doesn't make any financial sense to support the long tail.
 
-You can’t control how it’s built, how long it lives for, or how much butter they put in it.
+  Industrial software can only target the biggest problems for the most people, ideally wealthy people with disposable income.
 
-Has commercial interests at heart, rather than familial love and care.
+  This is an economic limitation. Building features that solve every single long tail need requires a lot of engineering labor...
 
-Less security and privacy – you don’t know where the data is going.
+  </div>
+  <div data-slide="27">
 
-</TalkSlide>
+  ...and engineers are very expensive.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_23.webp">
+  For industrial software, you need large teams of developers and designers and product people who demand high salaries in exchange for their valuable, hard-won expertise.
 
-And professional software is the kind of software almost everyone in the world uses. It's made for masses of people, at a global scale, by huge corporations.
+  </div>
+  <div data-slide="28">
 
-</TalkSlide>
+  And the way we fund this is primarily through US-based venture capital funding, which demands hockey stick growth in return.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_24.webp">
+  All the focus goes into making hundreds of millions or ideally billions of dollars in profit to pay back their investors.
 
-At the moment, we’re in the industrial, high-modernism age of software, where these standardized, one-size-fits-all apps are made for us by people who don’t know much about us.
+  As a member of a team that's in the middle of doing this, I can say it affects every single decision about how we build the software and what features are prioritized.
 
-</TalkSlide>
+  </div>
+  <div data-slide="29">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_25.webp">
+  I've drawn a little map to help make these dynamics clear.
 
-Primarily people working for large Californian corporations and shipping their software overseas.
+  We have scale on the horizontal axis, going from small, special snowflake software up to global industrial software.
 
-They’re sitting in San Fransisco trying to understand our pains and problems over Zoom calls and customer support tickets.
+  And profit on the vertical axis, so unicorn companies making billions of dollars versus financial sinkholes.
 
-They have so little context on our lives, what problems we need solved, and what we value.
+  </div>
+  <div data-slide="30">
 
-How could an American getting paid six figures in Mountain View understand how to identify problems and design solutions for a homemaker in Tokyo, a street seller in Turkey, or a doctor in Tunisia?
+  Most software today sits in this upper right quadrant of being large-scale and aiming to make as much money as possible.
 
-For the most part, they don’t. Or if they try, they do it badly.
+  </div>
+  <div data-slide="31">
 
-</TalkSlide>
+  Anything that falls below the profit line ends up being a short-lived failure—it's not allowed to survive long in the marketplace.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_26.webp">
+  </div>
+  <div data-slide="32">
 
-My friend Kasey Klimes wrote a fantastic piece called “[When to Design for Emergence](https://newsletter.rhizomerd.com/p/when-to-design-for-emergence)” on the design dynamics of large-scale software after working on Google Maps.
+  But over here on the left-hand side of small-scale, specific software, we have the land of opportunity.
 
-He points out that our current approach is designed to only solve the most common needs of the most number of users.
+  This kind of software doesn't even need to make a profit; it just has to operate at a very low cost, although maybe it could make some small to medium amount of profit over the long term.
 
-Anything beyond that is what we call the long tail of user needs. These are things only a few people need, but there's a nearly infinite amount of them.
+  </div>
+  <div data-slide="33">
 
-</TalkSlide>
+  But this land of opportunity currently has a skill issue.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_27.webp">
+  Because the Venn diagram of people with the skills to make home-cooked software and professional developers is essentially...
 
-In the case of Google Maps, the long tail of user needs is anything beyond "how do I get from here to there?”
+  </div>
+  <div data-slide="34">
 
-Google Maps is never going to support showing historical borders or tidal patterns, even if those things are essential to a few dozen, or even a few hundred people.
+  ...a concentric circle.
 
-</TalkSlide>
+  All the examples of home-cooked software I showed were made by people who work as professional developers.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_28.webp">
+  The vast majority of people who might want to make a piece of home-cooked software can't because software development is too complex. Even those of us who are professionals don't always have the right knowledge to make a full-stack app for ourselves.
 
-In the current system, this stuff is always considered out of scope.
+  This isn’t news to anyone. This has been the main complaint of end-user programming advocates for decades.
 
-Because it doesn't make any financial sense to support the long tail.
+  </div>
+  <div data-slide="35">
 
-Industrial software can only target the biggest problems for the most people, ideally wealthy people with disposable income.
+  So widespread, local, home-cooked software is still just a pipe dream.
 
-This is an economic limitation. Building features that solve every single long tail need requires a lot of engineering labor...
+  This is a shame because we know the world is full of problems to be solved. While not all of those problems have software-shaped solutions, a whole bunch of them do.
 
-</TalkSlide>
+  It's hard to argue it wouldn't be overwhelmingly net good for more people to be capable of designing and building their own software to solve problems for their local communities.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_29.webp">
+  </div>
+  <div data-slide="36">
 
-...and engineers are very expensive.
+  So what happens if some parts of software development get faster, easier, and cheaper?
 
-For industrial software, you need large teams of developers and designers and product people who demand high salaries in exchange for their valuable, hard-won expertise.
+  </div>
+  <div data-slide="37">
 
-</TalkSlide>
+  Well, 4 years ago, OpenAI released GPT-3, the first meaningfully capable large language model. And since then, we've been on a bit of a ride.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_30.webp">
+  Now, when I say large language model...
 
-And the way we fund this is primarily through US-based venture capital funding, which demands hockey stick growth in return.
+  </div>
+  <div data-slide="38">
 
-All the focus goes into making hundreds of millions or ideally billions of dollars in profit to pay back their investors.
+  I'm talking about what everyone else calls AI. But I think that term is too general.
 
-As a member of a team that's in the middle of doing this, I can say it affects every single decision about how we build the software and what features are prioritized.
+  </div>
+  <div data-slide="39">
 
-</TalkSlide>
+  I'm specifically talking about models that are made using deep learning and neural networks.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_31.webp">
+  These are primarily large language models, but this also includes vision and action models.
 
-I've drawn a little map to help make these dynamics clear.
+  They are models that can understand words, code syntax, images, and interface actions based on human training data.
 
-We have scale on the horizontal axis, going from small, special snowflake software up to global industrial software.
+  </div>
+  <div data-slide="40">
 
-And profit on the vertical axis, so unicorn companies making billions of dollars versus financial sinkholes.
+  I'm also talking about what's come to be called agents.
 
-</TalkSlide>
+  This is when we get large language models to behave like an agent that can make plans and decisions to try and achieve goals we give them.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_32.webp">
+  We give these agents access to external tools like web search, calculators, and the ability to write and run code.
 
-Most software today sits in this upper right quadrant of being large-scale and aiming to make as much money as possible.
+  As well as long-term memory stores in databases.
 
-</TalkSlide>
+  And we get them to mimic logical thought patterns like having them observe what they know, plan what they want to do next, critique their own work, and think step by step.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_33.webp">
+  The agent gets to decide what tool it wants to use at any one point to solve the problem we've given it.
 
-Anything that falls below the profit line ends up being a short-lived failure—it's not allowed to survive long in the marketplace.
+  </div>
+  <div data-slide="41">
 
-</TalkSlide>
+  This architecture of chaining together tools and logic makes language models far more capable than they would be otherwise.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_34.webp">
+  They end up being able to do quite sophisticated tasks within our existing programming environments.
 
-But over here on the left-hand side of small-scale, specific software, we have the land of opportunity.
+  </div>
+  <div data-slide="42">
 
-This kind of software doesn't even need to make a profit; it just has to operate at a very low cost, although maybe it could make some small to medium amount of profit over the long term.
+  Unless anyone here has been living under a rock, you know we've been deploying language models and agents into tools designed to help professional developers like GitHub Copilot, Cursor, and Replit.
 
-</TalkSlide>
+  </div>
+  <div data-slide="43">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_35.webp">
+  They can read and write code, debug things, create documentation, and write tests.
 
-But this land of opportunity currently has a skill issue.
+  One study showed that developers using Copilot were 55% faster at completing tasks, so we at least know this speeds people up.
 
-Because the Venn diagram of people with the skills to make home-cooked software and professional developers is essentially...
+  I can say from personal experience I am a much better programmer with access to these tools, but I appreciate there's a lot of skepticism and controversy over them.
 
-</TalkSlide>
+  Perhaps they’re just creating more crap code and bugs for everyone to deal with down the line.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_36.webp">
+  </div>
+  <div data-slide="44">
 
-...a concentric circle.
+  But I actually don't want to talk about how advances in AI will affect professional developers.
+  With all due respect, we have it pretty good. Our problems are boring.
 
-All the examples of home-cooked software I showed were made by people who work as professional developers.
+  I want to talk about a different kind of developer.
 
-The vast majority of people who might want to make a piece of home-cooked software can't because software development is too complex. Even those of us who are professionals don't always have the right knowledge to make a full-stack app for ourselves.
+  </div>
+  <div data-slide="45">
 
-This isn’t news to anyone. This has been the main complaint of end-user programming advocates for decades.
+  What I call barefoot developers.
 
-</TalkSlide>
+  This is a term I’ve made up, based on the idea of...
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_37.webp">
+  </div>
+  <div data-slide="46">
 
-So widespread, local, home-cooked software is still just a pipe dream.
+  Barefoot doctors.
 
-This is a shame because we know the world is full of problems to be solved. While not all of those problems have software-shaped solutions, a whole bunch of them do.
+  </div>
+  <div data-slide="47">
 
-It's hard to argue it wouldn't be overwhelmingly net good for more people to be capable of designing and building their own software to solve problems for their local communities.
+  Initiative by Mao’s government in China in the 1960s.
+  I'm not saying _everything_ Mao did was great, but this was a pretty good program. I'm sure he had very little to do with it.
 
-</TalkSlide>
+  At the time, 80% of the population lived in rural areas but had no or poor access to healthcare.
+  Medical expertise was all concentrated in urban areas.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_38.webp">
+  They selected people from rural villages and trained them up to become healthcare providers for their communities. These villagers were taught preventative care, curing simple ailments, diagnoses, and giving vaccines.
 
-So what happens if some parts of software development get faster, easier, and cheaper?
+  And then they would return to their home villages to serve the people they knew. They were still barefoot peasants like everyone else, but now with more skills.
 
-</TalkSlide>
+  The program was a wild success.
+  By the mid-1970s, there were over 1.5 million barefoot doctors serving in China's villages.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_39.webp">
+  Life expectancy over that period rose dramatically from 35 years to 63 years.
 
-Well, 4 years ago, OpenAI released GPT-3, the first meaningfully capable large language model. And since then, we've been on a bit of a ride.
+  </div>
+  <div data-slide="48">
 
-Now, when I say large language model...
+  The developer version isn’t going to be organized by a central government.
 
-</TalkSlide>
+  It only exists in very limited ways at the moment.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_40.webp">
+  </div>
+  <div data-slide="49">
 
-I'm talking about what everyone else calls AI. But I think that term is too general.
+  To explain this, we need to think about the scale of people interested in programming.
 
-</TalkSlide>
+  On one side, we have regular “end-users” of computers.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_41.webp">
+  Now, in theory, I’m a big proponent of end-user programming, but I have to admit most of these people don’t give a shit about programming and don’t want to learn it. I think we need to stop harassing normal nurses, teachers, and therapists to code when they don't want to.
 
-I'm specifically talking about models that are made using deep learning and neural networks.
+  </div>
+  <div data-slide="50">
 
-These are primarily large language models, but this also includes vision and action models.
+  So anyway, this is not about end-users.
 
-They are models that can understand words, code syntax, images, and interface actions based on human training data.
+  It is also not about professional developers on the other side of the scale.
 
-</TalkSlide>
+  We all love writing code for its own sake. We will invent excuses to program.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_42.webp">
+  </div>
+  <div data-slide="51">
 
-I'm also talking about what's come to be called agents.
+  Barefoot developers are going to be people who live in this middle bit.
 
-This is when we get large language models to behave like an agent that can make plans and decisions to try and achieve goals we give them.
+  </div>
+  <div data-slide="52">
 
-We give these agents access to external tools like web search, calculators, and the ability to write and run code.
+  At the moment, these are people like the teachers who make elaborate Notion spreadsheets for managing classes.
 
-As well as long-term memory stores in databases.
+  </div>
+  <div data-slide="53">
 
-And we get them to mimic logical thought patterns like having them observe what they know, plan what they want to do next, critique their own work, and think step by step.
+  Or students who make over-the-top personal dashboards.
 
-The agent gets to decide what tool it wants to use at any one point to solve the problem we've given it.
+  </div>
+  <div data-slide="54">
 
-</TalkSlide>
+  Or financial planning wonks producing extensive spreadsheets.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_43.webp">
+  </div>
+  <div data-slide="55">
 
-This architecture of chaining together tools and logic makes language models far more capable than they would be otherwise.
+  They are people who are technically savvy and interested in solving problems for themselves and people around them, but don't want to become fully-fledged programmers.
 
-They end up being able to do quite sophisticated tasks within our existing programming environments.
+  </div>
+  <div data-slide="56">
 
-</TalkSlide>
+  They still live within the world of end-user-facing applications.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_44.webp">
+  At the moment, they rely on low and no-code tools. And they do wildly complex things within them, pushing these apps to their limits.
 
-Unless anyone here has been living under a rock, you know we've been deploying language models and agents into tools designed to help professional developers like GitHub Copilot, Cursor, and Replit.
+  They are the kinds of people who would be thrilled to have more agency and power over computers.
 
-</TalkSlide>
+  </div>
+  <div data-slide="57">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_45.webp">
+  But they never make it over what I call the command line wall.
 
-They can read and write code, debug things, create documentation, and write tests.
+  They never end up in the terminal, because that is a huge jump in complexity, usability, and frustration from using something like Airtable or Notion.
 
-One study showed that developers using Copilot were 55% faster at completing tasks, so we at least know this speeds people up.
+  This means most of their work is held hostage in the cloud and requires them to pay monthly subscription fees to access it.
 
-I can say from personal experience I am a much better programmer with access to these tools, but I appreciate there's a lot of skepticism and controversy over them.
+  They have far less agency and power over their creations than full-blown developers.
 
-Perhaps they’re just creating more crap code and bugs for everyone to deal with down the line.
+  </div>
+  <div data-slide="58">
 
-</TalkSlide>
+  But I have this dream for barefoot developers that is like the barefoot doctor.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_46.webp">
+  These people are deeply embedded in their communities, so they understand the needs and problems of the people around them.
 
-But I actually don't want to talk about how advances in AI will affect professional developers.
-With all due respect, we have it pretty good. Our problems are boring.
+  So they are perfectly placed to solve local problems.
 
-I want to talk about a different kind of developer.
+  If given access to the right training and tools, they could provide the equivalent of basic healthcare, but instead, it’s basic software care.
 
-</TalkSlide>
+  </div>
+  <div data-slide="59">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_47.webp">
+  And they could become an unofficial, distributed, emergent public service.
 
-What I call barefoot developers.
+  They could build software solutions that no industrial software company would build—because there’s not enough market value in doing it, and they don’t understand the problem space well enough. This is the long tail of user needs.
 
-This is a term I’ve made up, based on the idea of...
+  And these people are the ones for whom our new language model capabilities get very interesting.
 
-</TalkSlide>
+  </div>
+  <div data-slide="60">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_48.webp">
+  I’m interested in the question of what language models can do for barefoot developers.
 
-Barefoot doctors.
+  </div>
+  <div data-slide="61">
 
-</TalkSlide>
+  This is a now infamous tweet by one of OpenAI's co-founders, Andrej Karpathy, claiming "The hottest new programming language is English.”
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_49.webp">
+  </div>
+  <div data-slide="62">
 
-Initiative by Mao’s government in China in the 1960s.
-I'm not saying _everything_ Mao did was great, but this was a pretty good program. I'm sure he had very little to do with it.
+  What he meant by this is that these models can accept natural language input in the form of descriptions of interfaces or software functionality and output working code.
 
-At the time, 80% of the population lived in rural areas but had no or poor access to healthcare.
-Medical expertise was all concentrated in urban areas.
+  </div>
+  <div data-slide="63">
 
-They selected people from rural villages and trained them up to become healthcare providers for their communities. These villagers were taught preventative care, curing simple ailments, diagnoses, and giving vaccines.
+  We are still in the very early days of this, but there are already a few prototypes out in the wild that show what's becoming possible.
 
-And then they would return to their home villages to serve the people they knew. They were still barefoot peasants like everyone else, but now with more skills.
+  This is [Vercel’s V0](https://v0.dev/). It generates working interfaces based on text descriptions of what you want.
 
-The program was a wild success.
-By the mid-1970s, there were over 1.5 million barefoot doctors serving in China's villages.
+  I've told it to make me a personal finance dashboard with feature cards showing me my daily purchases, my recent transactions, and my income over the last couple of months.
 
-Life expectancy over that period rose dramatically from 35 years to 63 years.
+  It’s given me three versions to pick from.
 
-</TalkSlide>
+  I can add follow-up instructions for how I want it to iterate on this interface. This gives me a good feedback loop.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_50.webp">
+  I asked to add accounts and bills pages to the sidebar.
+  It produced working code I can view and edit.
 
-The developer version isn’t going to be organized by a central government.
+  I can also directly select elements and ask it to edit them.
 
-It only exists in very limited ways at the moment.
+  </div>
+  <div data-slide="64">
 
-</TalkSlide>
+  Another good example of this is [TLDraw](https://tldraw.com/)'s [Make Real](https://makereal.tldraw.com/) prototype.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_51.webp">
+  I'm lucky enough to hang out with them sometimes and – unbiasedly – I think they're doing some of the most interesting work in generative interfaces.
 
-To explain this, we need to think about the scale of people interested in programming.
+  The odd thing is they're nominally just building whiteboarding software.
 
-On one side, we have regular “end-users” of computers.
+  But they hooked up a multi-modal language model (GPT-4 Omni) to their canvas so that you can draw any kind of interface you like and annotate it with red drawings and text to tell the system how you want it to work
 
-Now, in theory, I’m a big proponent of end-user programming, but I have to admit most of these people don’t give a shit about programming and don’t want to learn it. I think we need to stop harassing normal nurses, teachers, and therapists to code when they don't want to.
+  And then click this “make real” button and it will make your selection into a real working piece of software.
 
-</TalkSlide>
+  </div>
+  <div data-slide="65">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_52.webp">
+  Here's another one that instantly makes a photo booth app with a live camera feed from your device.
 
-So anyway, this is not about end-users.
+  This required no custom code to make work. GPT-4 Omni just made it work.
 
-It is also not about professional developers on the other side of the scale.
+  Because this environment is an infinite whiteboard, you can select your current prototype, add annotations to it, and generate new versions.
 
-We all love writing code for its own sake. We will invent excuses to program.
+  </div>
+  <div data-slide="66">
 
-</TalkSlide>
+  This [Make Real](https://makereal.tldraw.com/) tool is online – you can go use it now.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_53.webp">
+  If you're someone who's skeptical about the capabilities of language models, I suggest you spend some time playing with this.
 
-Barefoot developers are going to be people who live in this middle bit.
+  This all feels exceptionally promising for the future of local, home-cooked software.
 
-</TalkSlide>
+  </div>
+  <div data-slide="67">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_54.webp">
+  Remember that the stuff barefoot developers need to build is not as complex as professional industrial software we’re all used to working on.
 
-At the moment, these are people like the teachers who make elaborate Notion spreadsheets for managing classes.
+  They don't need to scale up to millions of people,
+  juggle conflicting user needs, or pivot their business plans, or ship lots of features very fast to make a high return for venture capitalists.
 
-</TalkSlide>
+  Most of the software needs of local communities could be solved with simple CRUD apps persisting data over time, with some basic user authentication, and a few API calls.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_55.webp">
+  </div>
+  <div data-slide="68">
 
-Or students who make over-the-top personal dashboards.
+  So as much as I expect the number of professional developers to grow in the coming years.
 
-</TalkSlide>
+  </div>
+  <div data-slide="69">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_56.webp">
+  I expect the number of barefoot developers to grow exponentially more.
 
-Or financial planning wonks producing extensive spreadsheets.
+  </div>
+  <div data-slide="70">
 
-</TalkSlide>
+  But to get to that world of millions of barefoot developers, we have some problems to work through in the current moment.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_57.webp">
+  And the way I'm going to put this is that language model legos need glue.
 
-They are people who are technically savvy and interested in solving problems for themselves and people around them, but don't want to become fully-fledged programmers.
+  </div>
+  <div data-slide="71">
 
-</TalkSlide>
+  Language models give you a bunch of disconnected lego pieces.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_58.webp">
+  </div>
+  <div data-slide="72">
 
-They still live within the world of end-user-facing applications.
+  It can make pretty interface elements for you,
+  it can manage state for you,
+  make API calls, and
+  write basic logic. But it doesn't tell you how to stick all these things together into a working application.
 
-At the moment, they rely on low and no-code tools. And they do wildly complex things within them, pushing these apps to their limits.
+  </div>
+  <div data-slide="73">
 
-They are the kinds of people who would be thrilled to have more agency and power over computers.
+  Meanwhile, you want a cool castle, and it's very unclear how you are supposed to make a castle from these disconnected lego pieces.
 
-</TalkSlide>
+  At the moment, you still need the knowledge of professional developers to glue them together.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_59.webp">
+  </div>
+  <div data-slide="74">
 
-But they never make it over what I call the command line wall.
+  If you generate something in [Vercel’s V0](https://v0.dev/) or [TLDraw](https://tldraw.com/) you still have no idea how you might deploy that to a particular web domain or to your iPhone.
 
-They never end up in the terminal, because that is a huge jump in complexity, usability, and frustration from using something like Airtable or Notion.
+  Or persist data by setting up a database. You probably don't know what a database is.
 
-This means most of their work is held hostage in the cloud and requires them to pay monthly subscription fees to access it.
+  Add multiplayer collaboration
 
-They have far less agency and power over their creations than full-blown developers.
+  Have multiple users log in with different view and editing permissions
 
-</TalkSlide>
+  And 99 others I haven’t thought of that Hacker News will tell me about later.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_60.webp">
+  </div>
+  <div data-slide="75">
 
-But I have this dream for barefoot developers that is like the barefoot doctor.
+  We're missing the glue that brings all these pieces together into working software. And the glue comes in two forms.
 
-These people are deeply embedded in their communities, so they understand the needs and problems of the people around them.
+  We first need language model agents that are designed to act as central orchestrators for home-cooked software projects.
 
-So they are perfectly placed to solve local problems.
+  These agents can guide barefoot developers through the process of writing technical specifications and help them work out what kinds of tools they might need for a piece of software.
 
-If given access to the right training and tools, they could provide the equivalent of basic healthcare, but instead, it’s basic software care.
+  </div>
+  <div data-slide="76">
 
-</TalkSlide>
+  And then we also need tools that are designed to talk to and work with these orchestration agents.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_61.webp">
+  I expect these agents will have a set of default tools they’ve been taught how to use and call on whenever their human needs to build some new software.
 
-And they could become an unofficial, distributed, emergent public service.
+  These might be APIs to multiplayer collaboration infrastructure, database managers, and deployment pipelines.
 
-They could build software solutions that no industrial software company would build—because there’s not enough market value in doing it, and they don’t understand the problem space well enough. This is the long tail of user needs.
+  </div>
+  <div data-slide="77">
 
-And these people are the ones for whom our new language model capabilities get very interesting.
+  Which brings me back to the topic near and dear to all of your hearts. Local-first.
 
-</TalkSlide>
+  If I'm at all right about there being a sudden explosion of local, home-cooked software, how does this affect the strategy of the local-first movement?
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_62.webp">
+  How would you try and make sure local-first is baked into this future by default?
 
-I’m interested in the question of what language models can do for barefoot developers.
+  </div>
+  <div data-slide="78">
 
-</TalkSlide>
+  Because this default tool set for barefoot developers should really have a database that’s a local-first database, right?
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_63.webp">
+  And once their apps are deployed, it would be nice if they worked offline, right?
 
-This is a now infamous tweet by one of OpenAI's co-founders, Andrej Karpathy, claiming "The hottest new programming language is English.”
+  Barefoot developers might not know to ask for these things in their technical specs or prompts. Whatever defaults are baked into these agents and their available tools are going to make a lot of decisions for them.
 
-</TalkSlide>
+  </div>
+  <div data-slide="79">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_64.webp">
+  If you're currently building local-first tools, you should consider what kinds of interfaces would make them accessible to barefoot developers and their future agents.
 
-What he meant by this is that these models can accept natural language input in the form of descriptions of interfaces or software functionality and output working code.
+  Can someone prompt their way into a local-first setup in plain English? Could they write a technical spec in markdown and end up with a working database?
 
-</TalkSlide>
+  </div>
+  <div data-slide="80">
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_65.webp">
+  Could you develop your own small language model that guides someone through setting up your tool?
 
-We are still in the very early days of this, but there are already a few prototypes out in the wild that show what's becoming possible.
+  </div>
+  <div data-slide="81">
 
-This is [Vercel’s V0](https://v0.dev/). It generates working interfaces based on text descriptions of what you want.
+  Frankly, can you stick [TLDraw](https://tldraw.com/) onto the front of your system and start letting people build full-stack apps with it?
 
-I've told it to make me a personal finance dashboard with feature cards showing me my daily purchases, my recent transactions, and my income over the last couple of months.
+  </div>
+  <div data-slide="82">
 
-It’s given me three versions to pick from.
+  To give you some motivation, I want you to imagine a future where we do get the explosion of local, home-cooked software, but it's not local-first.
 
-I can add follow-up instructions for how I want it to iterate on this interface. This gives me a good feedback loop.
+  </div>
+  <div data-slide="83">
 
-I asked to add accounts and bills pages to the sidebar.
-It produced working code I can view and edit.
+  We get powerful, flexible tools that let barefoot developers make lots and lots of local, home-cooked software. They solve all kinds of specific, local problems for the people around them. Their communities love it. They become dependent on what they’ve built.
 
-I can also directly select elements and ask it to edit them.
+  </div>
+  <div data-slide="84">
 
-</TalkSlide>
+  But the software and the data behind it are all held in the cloud. And you have to keep paying a monthly subscription fee to access it. And then suddenly the terms of service change. And there's a giant advertisement in the middle of every homepage. And the subscription fee doubles.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_66.webp">
+  And it turns out what they’ve built was never actually theirs all along.
 
-Another good example of this is [TLDraw](https://tldraw.com/)'s [Make Real](https://makereal.tldraw.com/) prototype.
+  I expect that would be a super lucrative business model.
 
-I'm lucky enough to hang out with them sometimes and – unbiasedly – I think they're doing some of the most interesting work in generative interfaces.
+  </div>
+  <div data-slide="85">
 
-The odd thing is they're nominally just building whiteboarding software.
+  So I think you should care about this because the local-first movement and the local, home-cooked software vision are distinct but philosophically aligned.
 
-But they hooked up a multi-modal language model (GPT-4 Omni) to their canvas so that you can draw any kind of interface you like and annotate it with red drawings and text to tell the system how you want it to work
+  </div>
+  <div data-slide="86">
 
-And then click this “make real” button and it will make your selection into a real working piece of software.
+  They’re built on the same foundational values: that users should have agency and ownership over their data and software.
 
-</TalkSlide>
+  At the moment this community is focused on solving hard technical problems, but you should keep an eye on what’s developing around you as parts of the software-making process rapidly become more accessible and democratized.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_67.webp">
+  We can weave the local and local-first philosophies together and build tools that serve both of them. I really want local-first to be the default choice for local software. The alternative feels unquestionably worse.
 
-Here's another one that instantly makes a photo booth app with a live camera feed from your device.
+  The extent to which these two visions overlap and complement each other is up to everyone in this community to decide.
 
-This required no custom code to make work. GPT-4 Omni just made it work.
+  </div>
+  <div data-slide="87">
 
-Because this environment is an infinite whiteboard, you can select your current prototype, add annotations to it, and generate new versions.
+  I want to end this with a quote by Ivan Illich, who I'm sure many of you have heard of.
 
-</TalkSlide>
+  He wrote a wonderful book called "[Tools for Conviviality](https://en.wikipedia.org/wiki/Tools_for_Conviviality)" where he talked about the importance of people being able to make tools for themselves.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_68.webp">
+  He says, "People need not only to obtain things; they need above all the freedom to make things among which they can live, to give shape to them according to their own tastes, and to put them to use in caring for and about others."
 
-This [Make Real](https://makereal.tldraw.com/) tool is online – you can go use it now.
+  Software is no exception to this.
 
-If you're someone who's skeptical about the capabilities of language models, I suggest you spend some time playing with this.
+  </div>
+  <div data-slide="88">
 
-This all feels exceptionally promising for the future of local, home-cooked software.
+  That is the end of my talk. Thank you very much for listening.
 
-</TalkSlide>
+  I want to say this was a very challenging talk to write and it's the first time I've done it. I had to try to make some very big claims and back them up.
 
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_69.webp">
+  I would really love constructive criticism about places you think I'm wrong or I've overlooked important details. Just please be kind about it.
 
-Remember that the stuff barefoot developers need to build is not as complex as professional industrial software we’re all used to working on.
-
-They don't need to scale up to millions of people,
-juggle conflicting user needs, or pivot their business plans, or ship lots of features very fast to make a high return for venture capitalists.
-
-Most of the software needs of local communities could be solved with simple CRUD apps persisting data over time, with some basic user authentication, and a few API calls.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_70.webp">
-
-So as much as I expect the number of professional developers to grow in the coming years.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_71.webp">
-
-I expect the number of barefoot developers to grow exponentially more.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_72.webp">
-
-But to get to that world of millions of barefoot developers, we have some problems to work through in the current moment.
-
-And the way I'm going to put this is that language model legos need glue.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_73.webp">
-
-Language models give you a bunch of disconnected lego pieces.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_74.webp">
-
-It can make pretty interface elements for you,
-it can manage state for you,
-make API calls, and
-write basic logic. But it doesn't tell you how to stick all these things together into a working application.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_75.webp">
-
-Meanwhile, you want a cool castle, and it's very unclear how you are supposed to make a castle from these disconnected lego pieces.
-
-At the moment, you still need the knowledge of professional developers to glue them together.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_76.webp">
-
-If you generate something in [Vercel’s V0](https://v0.dev/) or [TLDraw](https://tldraw.com/) you still have no idea how you might deploy that to a particular web domain or to your iPhone.
-
-Or persist data by setting up a database. You probably don't know what a database is.
-
-Add multiplayer collaboration
-
-Have multiple users log in with different view and editing permissions
-
-And 99 others I haven’t thought of that Hacker News will tell me about later.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_77.webp">
-
-We're missing the glue that brings all these pieces together into working software. And the glue comes in two forms.
-
-We first need language model agents that are designed to act as central orchestrators for home-cooked software projects.
-
-These agents can guide barefoot developers through the process of writing technical specifications and help them work out what kinds of tools they might need for a piece of software.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_78.webp">
-
-And then we also need tools that are designed to talk to and work with these orchestration agents.
-
-I expect these agents will have a set of default tools they’ve been taught how to use and call on whenever their human needs to build some new software.
-
-These might be APIs to multiplayer collaboration infrastructure, database managers, and deployment pipelines.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_79.webp">
-
-Which brings me back to the topic near and dear to all of your hearts. Local-first.
-
-If I'm at all right about there being a sudden explosion of local, home-cooked software, how does this affect the strategy of the local-first movement?
-
-How would you try and make sure local-first is baked into this future by default?
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_80.webp">
-
-Because this default tool set for barefoot developers should really have a database that’s a local-first database, right?
-
-And once their apps are deployed, it would be nice if they worked offline, right?
-
-Barefoot developers might not know to ask for these things in their technical specs or prompts. Whatever defaults are baked into these agents and their available tools are going to make a lot of decisions for them.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_81.webp">
-
-If you're currently building local-first tools, you should consider what kinds of interfaces would make them accessible to barefoot developers and their future agents.
-
-Can someone prompt their way into a local-first setup in plain English? Could they write a technical spec in markdown and end up with a working database?
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_82.webp">
-
-Could you develop your own small language model that guides someone through setting up your tool?
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_83.webp">
-
-Frankly, can you stick [TLDraw](https://tldraw.com/) onto the front of your system and start letting people build full-stack apps with it?
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_84.webp">
-
-To give you some motivation, I want you to imagine a future where we do get the explosion of local, home-cooked software, but it's not local-first.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_85.webp">
-
-We get powerful, flexible tools that let barefoot developers make lots and lots of local, home-cooked software. They solve all kinds of specific, local problems for the people around them. Their communities love it. They become dependent on what they’ve built.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_86.webp">
-
-But the software and the data behind it are all held in the cloud. And you have to keep paying a monthly subscription fee to access it. And then suddenly the terms of service change. And there's a giant advertisement in the middle of every homepage. And the subscription fee doubles.
-
-And it turns out what they’ve built was never actually theirs all along.
-
-I expect that would be a super lucrative business model.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_87.webp">
-
-So I think you should care about this because the local-first movement and the local, home-cooked software vision are distinct but philosophically aligned.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_88.webp">
-
-They’re built on the same foundational values: that users should have agency and ownership over their data and software.
-
-At the moment this community is focused on solving hard technical problems, but you should keep an eye on what’s developing around you as parts of the software-making process rapidly become more accessible and democratized.
-
-We can weave the local and local-first philosophies together and build tools that serve both of them. I really want local-first to be the default choice for local software. The alternative feels unquestionably worse.
-
-The extent to which these two visions overlap and complement each other is up to everyone in this community to decide.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_89.webp">
-
-I want to end this with a quote by Ivan Illich, who I'm sure many of you have heard of.
-
-He wrote a wonderful book called "[Tools for Conviviality](https://en.wikipedia.org/wiki/Tools_for_Conviviality)" where he talked about the importance of people being able to make tools for themselves.
-
-He says, "People need not only to obtain things; they need above all the freedom to make things among which they can live, to give shape to them according to their own tastes, and to put them to use in caring for and about others."
-
-Software is no exception to this.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/home-cooked-software/hcs_90.webp">
-
-That is the end of my talk. Thank you very much for listening.
-
-I want to say this was a very challenging talk to write and it's the first time I've done it. I had to try to make some very big claims and back them up.
-
-I would really love constructive criticism about places you think I'm wrong or I've overlooked important details. Just please be kind about it.
-
-</TalkSlide>
+  </div>
+</ScrollyTalkSection>

--- a/src/content/talks/squish-structure.mdx
+++ b/src/content/talks/squish-structure.mdx
@@ -24,7 +24,7 @@ conferences:
 cover: "../../images/covers/talk-sms@2x.png"
 ---
 
-import TalkSlide from "../../components/mdx/TalkSlide.astro";
+import ScrollyTalkSection from "../../components/mdx/ScrollyTalkSection.astro";
 import GridColumns from "../../components/mdx/GridColumns.astro";
 import Video from "../../components/mdx/Video.astro";
 import YearsAgo from "../../components/mdx/YearsAgo.astro";
@@ -61,757 +61,760 @@ Talk runs from 0:00 - 34:30, Q&A from 34:30 - end
 <Spacer size="small" />
 
 ## Slides and Transcript
+<ScrollyTalkSection images={[
+  "/images/posts/squish-structure/sms2.1.jpeg",
+  "/images/posts/squish-structure/sms2.2.jpeg",
+  "/images/posts/squish-structure/sms2.3.jpeg",
+  "/images/posts/squish-structure/sms2.4.jpeg",
+  "/images/posts/squish-structure/sms2.5.jpeg",
+  "/images/posts/squish-structure/sms2.6.jpeg",
+  "/images/posts/squish-structure/sms2.7.jpeg",
+  "/images/posts/squish-structure/sms2.8.jpeg",
+  "/images/posts/squish-structure/sms2.9.jpeg",
+  "/images/posts/squish-structure/sms2.10.jpeg",
+  "/images/posts/squish-structure/sms2.11.jpeg",
+  "/images/posts/squish-structure/sms2.12.jpeg",
+  "/images/posts/squish-structure/sms2.13.jpeg",
+  "/images/posts/squish-structure/sms2.14.jpeg",
+  "/images/posts/squish-structure/sms2.15.jpeg",
+  "/images/posts/squish-structure/sms2.16.jpeg",
+  "/images/posts/squish-structure/sms2.17.jpeg",
+  "/images/posts/squish-structure/sms2.18.jpeg",
+  "/images/posts/squish-structure/sms2.19.jpeg",
+  "/images/posts/squish-structure/sms2.20.jpeg",
+  "/images/posts/squish-structure/sms2.21.jpeg",
+  "/images/posts/squish-structure/sms2.22.jpeg",
+  "/images/posts/squish-structure/sms2.23.jpeg",
+  "/images/posts/squish-structure/sms2.24.jpeg",
+  "/images/posts/squish-structure/sms2.25.jpeg",
+  "/images/posts/squish-structure/sms2.26.jpeg",
+  "/images/posts/squish-structure/sms2.27.jpeg",
+  "/images/posts/squish-structure/sms2.28.jpeg",
+  "/images/posts/squish-structure/sms2.29.jpeg",
+  "/images/posts/squish-structure/sms2.30.jpeg",
+  "/images/posts/squish-structure/sms2.31.jpeg",
+  "/images/posts/squish-structure/sms2.32.jpeg",
+  "/images/posts/squish-structure/sms2.33.jpeg",
+  "/images/posts/squish-structure/sms2.34.jpeg",
+  "/images/posts/squish-structure/sms2.35.jpeg",
+  "/images/posts/squish-structure/sms2.36.jpeg",
+  "/images/posts/squish-structure/sms2.37.jpeg",
+  "/images/posts/squish-structure/sms2.38.jpeg",
+  "/images/posts/squish-structure/sms2.39.jpeg",
+  "/images/posts/squish-structure/sms2.40.jpeg",
+  "/images/posts/squish-structure/sms2.41.jpeg",
+  "/images/posts/squish-structure/sms2.42.jpeg",
+  "/images/posts/squish-structure/sms2.43.jpeg",
+  "/images/posts/squish-structure/sms2.44.jpeg",
+  "/images/posts/squish-structure/sms2.45.jpeg",
+  "/images/posts/squish-structure/sms2.46.jpeg",
+  "/images/posts/squish-structure/sms2.47.jpeg",
+  "/images/posts/squish-structure/sms2.48.jpeg",
+  "/images/posts/squish-structure/sms2.49.jpeg",
+  "/images/posts/squish-structure/sms2.50.jpeg",
+  "/images/posts/squish-structure/sms2.51.jpeg",
+  "/images/posts/squish-structure/sms2.52.jpeg",
+  "/images/posts/squish-structure/sms2.77.jpg",
+  "/images/posts/squish-structure/sms2.54.jpeg",
+  "/images/posts/squish-structure/sms2.55.jpeg",
+  "/images/posts/squish-structure/sms2.56.jpeg",
+  "/images/posts/squish-structure/sms2.57.jpeg",
+  "/images/posts/squish-structure/sms2.58.jpeg",
+  "/images/posts/squish-structure/sms2.59.jpeg",
+  "/images/posts/squish-structure/sms2.61.jpeg",
+  "/images/posts/squish-structure/sms2.62.jpeg",
+  "/images/posts/squish-structure/sms2.63.jpeg",
+  "/images/posts/squish-structure/sms2.64.jpeg",
+  "/images/posts/squish-structure/sms2.65.jpeg",
+  "/images/posts/squish-structure/sms2.66.jpeg",
+  "/images/posts/squish-structure/sms2.67.jpeg",
+  "/images/posts/squish-structure/sms2.68.jpeg",
+  "/images/posts/squish-structure/sms2.69.jpeg",
+  "/images/posts/squish-structure/sms2.70.jpeg",
+  "/images/posts/squish-structure/sms2.71.jpeg",
+  "/images/posts/squish-structure/sms2.74.jpeg",
+  "/images/posts/squish-structure/sms2.75.jpeg",
+  "/images/posts/squish-structure/sms2.76.jpeg",
+]}>
+<div data-slide="0">
+
+  This talk is going to be about designing products with language models.
+
+  Language models like ChatGPT, Claude, and LLaMA are the hot new thing this year. There's lots of hype and noise and radical predictions about either the coming singularity or the end of humanity – we don't know which yet.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.1.jpeg" >
+  But there's not a lot of clear-heading guidance on how to think about them or work with them. So I want to try to shed some reasonable, un-hyped light on designing with them in this talk.
 
-This talk is going to be about designing products with language models.
+  </div>
+  <div data-slide="1">
 
-Language models like ChatGPT, Claude, and LLaMA are the hot new thing this year. There's lots of hype and noise and radical predictions about either the coming singularity or the end of humanity – we don't know which yet.
+  First, some context about me.
+  I'm Maggie. I look like this on the Internet.
 
-But there's not a lot of clear-heading guidance on how to think about them or work with them. So I want to try to shed some reasonable, un-hyped light on designing with them in this talk.
+  I'm a product designer for a company called [Elicit](https://elicit.com), which uses language models to create tools for professional researchers and academics. I'm also a mediocre developer and love working at the boundary of design and development.
 
-</TalkSlide>
+  I originally trained as a cultural anthropologist which makes me look at everything through the lens of culture.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.2.jpeg">
+  I'm also a [[Tools for Thought]] enthusiast which is what made me interested in language models in the first place.
 
-First, some context about me.
-I'm Maggie. I look like this on the Internet.
+  </div>
+  <div data-slide="2">
 
-I'm a product designer for a company called [Elicit](https://elicit.com), which uses language models to create tools for professional researchers and academics. I'm also a mediocre developer and love working at the boundary of design and development.
+  Before I dive into talking about designing with language models we should talk about what language models actually are.
 
-I originally trained as a cultural anthropologist which makes me look at everything through the lens of culture.
+  </div>
+  <div data-slide="3">
 
-I'm also a [[Tools for Thought]] enthusiast which is what made me interested in language models in the first place.
+  Underneath the deceptively simple chatbot interfaces we’ve all been talking to is a huge mathematical model of human language.
 
-</TalkSlide>
+  One that understands how we structure words and sentences and paragraphs and the relationships between them.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.3.jpeg">
+  Which allows it to _mimic_ human language.
 
-Before I dive into talking about designing with language models we should talk about what language models actually are.
+  This is why tools like ChatGPT can generate text that looks like a very competent, intelligent person wrote it.
 
-</TalkSlide>
+  </div>
+  <div data-slide="4">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.4.jpeg">
+  Let's run through a quick story about how language models came into existence.
 
-Underneath the deceptively simple chatbot interfaces we’ve all been talking to is a huge mathematical model of human language.
+  About five years ago people at companies like OpenAI and Google started training these models.
 
-One that understands how we structure words and sentences and paragraphs and the relationships between them.
+  </div>
+  <div data-slide="5">
 
-Which allows it to _mimic_ human language.
+  To train a model you need an enormous volume of words. And they primarily got those words from the internet.
 
-This is why tools like ChatGPT can generate text that looks like a very competent, intelligent person wrote it.
+  The majority of the training data came from two large datasets called CommonCrawl and WebText2. These are huge scrapes of the open web. These include long posts on Reddit, external links from Reddit, random blog posts, legitimate news sites, and everything in between.
 
-</TalkSlide>
+  About 15% of the training data was legitimate published books.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.5.jpeg">
+  And they chucked in everything on Wikipedia, which surprisingly only added up to 3%.
 
-Let's run through a quick story about how language models came into existence.
+  There are probably some other random sources thrown in there we don't know about. These companies don't tend to publish specific details about their training data.
 
-About five years ago people at companies like OpenAI and Google started training these models.
+  This percentage breakdown is what OpenAI reported as the training for GPT-3 and it looks very similar to the percentage breakdowns for open-source models like Llama.
 
-</TalkSlide>
+  </div>
+  <div data-slide="6">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.6.jpeg">
+  So anyway, they fed all these words into something called a neural network...
 
-To train a model you need an enormous volume of words. And they primarily got those words from the internet.
+  </div>
+  <div data-slide="7">
 
-The majority of the training data came from two large datasets called CommonCrawl and WebText2. These are huge scrapes of the open web. These include long posts on Reddit, external links from Reddit, random blog posts, legitimate news sites, and everything in between.
+  ...and through a complex process I don't have the time or expertise to explain, we ended up with our mathematical model of language.
 
-About 15% of the training data was legitimate published books.
+  But the thing is, it didn’t just capture the structure of our language.
+  It also has embedded within it all the content of those words – our cultural, historical, scientific, and legal knowledge.
 
-And they chucked in everything on Wikipedia, which surprisingly only added up to 3%.
+  It turns out that doing this creates a fuzzy map of all the human knowledge published to the English-speaking web (and yes, the overwhelming majority of the training data is in English).
 
-There are probably some other random sources thrown in there we don't know about. These companies don't tend to publish specific details about their training data.
+  Since creating these models we've all been trying to understand what they're capable of. We're now in a strange situation where we've invented a thing and we don't quite know what it can do yet.
 
-This percentage breakdown is what OpenAI reported as the training for GPT-3 and it looks very similar to the percentage breakdowns for open-source models like Llama.
+  </div>
+  <div data-slide="8">
 
-</TalkSlide>
+  One thing we know it’s definitely good at is predicting what words come next in a sequence.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.7.jpeg">
+  If I give it the phrase "Rubber ducks are...” and tell it to complete that sentence, comes up with a bunch of predictions for what's most likely to come next based on its training data
 
-So anyway, they fed all these words into something called a neural network...
+  It's likely to say rubber ducks are yellow or small toys used in the bath.
 
-</TalkSlide>
+  This prediction ability seems like a simple party trick but it's what makes models so good at answering our random questions in the way Google used to be.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.8.jpeg">
+  When you ask a language model for the answer to a question, statistically, it's going the complete that question with the correct answer more often than not. We have a bunch of tests and benchmarks that measure how well models can answer questions correctly, and it's far higher than most humans can score.
 
-...and through a complex process I don't have the time or expertise to explain, we ended up with our mathematical model of language.
+  Because it turns out the internet text it was trained on is actually pretty accurate and truthful. Despite what we may think about the quality of information on Reddit.
 
-But the thing is, it didn’t just capture the structure of our language.
-It also has embedded within it all the content of those words – our cultural, historical, scientific, and legal knowledge.
+  </div>
+  <div data-slide="9">
 
-It turns out that doing this creates a fuzzy map of all the human knowledge published to the English-speaking web (and yes, the overwhelming majority of the training data is in English).
+  We can get them to do other tricks too.
 
-Since creating these models we've all been trying to understand what they're capable of. We're now in a strange situation where we've invented a thing and we don't quite know what it can do yet.
+  Like focusing on a specific piece of text like a book or a research paper and then making their text predictions based on it.
 
-</TalkSlide>
+  They can then summarise that text quite accurately.
+  Or pull out key points from it.
+  Or answer questions about it.
+  Or explain it to us like we’re five.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.9.jpeg">
+  You can imagine how useful this is in education and research contexts.
 
-One thing we know it’s definitely good at is predicting what words come next in a sequence.
+  </div>
+  <div data-slide="10">
 
-If I give it the phrase "Rubber ducks are...” and tell it to complete that sentence, comes up with a bunch of predictions for what's most likely to come next based on its training data
+  They’re also able to understand the similarities or differences between sentences in a very precise mathematical way.
 
-It's likely to say rubber ducks are yellow or small toys used in the bath.
+  Let's take a sentence like “Freiburg has excellent pretzels”.
 
-This prediction ability seems like a simple party trick but it's what makes models so good at answering our random questions in the way Google used to be.
+  </div>
+  <div data-slide="11">
 
-When you ask a language model for the answer to a question, statistically, it's going the complete that question with the correct answer more often than not. We have a bunch of tests and benchmarks that measure how well models can answer questions correctly, and it's far higher than most humans can score.
+  We can calculate _exactly_ how different a sentence like “Freiburg makes baked goods” is with a numeric value. In this case, it has a similarity of 0.711, where 1 would be a perfect match.
 
-Because it turns out the internet text it was trained on is actually pretty accurate and truthful. Despite what we may think about the quality of information on Reddit.
+  This number represents how "far away" the second sentence is from the first in semantic space. Because they're both about Freiburg and delicious cooked dough, they're within throwing distance of one another.
 
-</TalkSlide>
+  A completely different sentence like “design is hard” has a score of 0.026 – it is much further away in composition and meaning.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.10.jpeg">
+  A slightly more random sentence like “Angry plastic cowboys?” has a negative score of -0.034.
 
-We can get them to do other tricks too.
+  Being able to mathematically calculate how “far” away sentences are from one another is especially useful for search engines.
 
-Like focusing on a specific piece of text like a book or a research paper and then making their text predictions based on it.
+  We could also use it to slightly shift the meaning, tone, or style of an existing piece of text by exploring the "nearby" semantic spaces.
 
-They can then summarise that text quite accurately.
-Or pull out key points from it.
-Or answer questions about it.
-Or explain it to us like we’re five.
+  You can play with sentence similarty calculators to get a feel for this on [Hugging Face](https://huggingface.co/tasks/sentence-similarity)
 
-You can imagine how useful this is in education and research contexts.
+  </div>
+  <div data-slide="12">
 
-</TalkSlide>
+  Let's try moving this sentence around in this semantic space.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.11.jpeg">
+  We can “move” this sentence towards being more cat-like or more dog-like using language models.
 
-They’re also able to understand the similarities or differences between sentences in a very precise mathematical way.
+  Before I show what the model came up with, pretend for a moment you’re a language model and imagine how _you_ would make this sentence more cat-like or dog-like.
 
-Let's take a sentence like “Freiburg has excellent pretzels”.
+  </div>
+  <div data-slide="13">
 
-</TalkSlide>
+  GPT-4 managed to come up with some fairly clever puns and wordplay to make this work. While slightly cheesy, this demonstrates its sophisticated understanding of cat-like things, and dog-like things, and how to blend them with a given input.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.12.jpeg">
+  I bet it did better than you did, right?
 
-We can calculate _exactly_ how different a sentence like “Freiburg makes baked goods” is with a numeric value. In this case, it has a similarity of 0.711, where 1 would be a perfect match.
+  Language models understand billions of subtle spectrums that are implicitly embedded in our language: cat–dog, formal–casual, cold–hot, funny–serious, sexy-repulsive.
 
-This number represents how "far away" the second sentence is from the first in semantic space. Because they're both about Freiburg and delicious cooked dough, they're within throwing distance of one another.
+  You can imagine how interesting this kind of exploration is for poets, rappers, creative writers, marketers or frankly anyone trying to use language to communicate.
 
-A completely different sentence like “design is hard” has a score of 0.026 – it is much further away in composition and meaning.
+  We’ve made super-advanced linguistic calculators.
 
-A slightly more random sentence like “Angry plastic cowboys?” has a negative score of -0.034.
+  </div>
+  <div data-slide="14">
 
-Being able to mathematically calculate how “far” away sentences are from one another is especially useful for search engines.
+  To put this all in perspective let’s talk about how brand new language models are. Here’s a timeline of recent events.
 
-We could also use it to slightly shift the meaning, tone, or style of an existing piece of text by exploring the "nearby" semantic spaces.
+  GPT 3, which was the first really impressive and capable language model, was released by OpenAI in May <YearsAgo>2020</YearsAgo>. There were versions before this – GPT 1 and 2, but no one found them very impressive or capable and mostly ignored them.
 
-You can play with sentence similarty calculators to get a feel for this on [Hugging Face](https://huggingface.co/tasks/sentence-similarity)
+  It's been three whole years since we've had these things! A lifetime in AI world.
 
-</TalkSlide>
+  Github Copilot came out about a year later in June <YearsAgo>2021</YearsAgo>. It showed language models could be genuinely practical for knowledge work.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.13.jpeg">
+  I started learning about language models in February of <YearsAgo>2022</YearsAgo>, around 18 months ago. This turned out to be _just_ before the language model hype phase. GPT-3 existed, but very few people knew about it or cared. I joined Elicit in the summer of that year. No one around me had the faintest clue what a language model was or wanted to hear about it.
 
-Let's try moving this sentence around in this semantic space.
+  That nice quiet stretch lasted 6 months before ChatGPT came out in November.
 
-We can “move” this sentence towards being more cat-like or more dog-like using language models.
+  And suddenly everyone cared a _ton_. Even though the underlying technology hadn't changed that much.
 
-Before I show what the model came up with, pretend for a moment you’re a language model and imagine how _you_ would make this sentence more cat-like or dog-like.
+  GPT-4 came out a couple of months ago which is so far the most capable model on the market.
 
-</TalkSlide>
+  So I feel like I have a very small headstart on this stuff. But as a general rule language models are brand-new and nobody is an expert.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.14.jpeg">
+  </div>
+  <div data-slide="15">
 
-GPT-4 managed to come up with some fairly clever puns and wordplay to make this work. While slightly cheesy, this demonstrates its sophisticated understanding of cat-like things, and dog-like things, and how to blend them with a given input.
+  I mentioned [Elicit](https://elicit.com) earlier. This is the product I’m the sole designer on.
 
-I bet it did better than you did, right?
+  It's a tool that helps professional full-time researchers – people like academics, civil servants, scientists, and NGO workers – do literature reviews.
 
-Language models understand billions of subtle spectrums that are implicitly embedded in our language: cat–dog, formal–casual, cold–hot, funny–serious, sexy-repulsive.
+  Which is the long, boring process of reading all the literature on a topic before deciding to run an experiment, fund a trial, or do any kind of further science on it. This could be anywhere from hundreds to tens of thousands of papers.
 
-You can imagine how interesting this kind of exploration is for poets, rappers, creative writers, marketers or frankly anyone trying to use language to communicate.
+  </div>
+  <div data-slide="16">
 
-We’ve made super-advanced linguistic calculators.
+  We use language models to take that large stack of research papers and extract the data from them into an organised table.
 
-</TalkSlide>
+  Researchers currently do this manually by opening hundreds of PDFs, scanning through them for important data points, and copying them into a large Google Sheet or Excel table. It is laborious work and can take up to a few months. We’re trying to cut that down to a few days or hours.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.15.jpeg">
+  </div>
+  <div data-slide="17">
 
-To put this all in perspective let’s talk about how brand new language models are. Here’s a timeline of recent events.
+  This is what it currently looks like.
 
-GPT 3, which was the first really impressive and capable language model, was released by OpenAI in May <YearsAgo>2020</YearsAgo>. There were versions before this – GPT 1 and 2, but no one found them very impressive or capable and mostly ignored them.
+  You ask a research question, and it finds papers for you or you can upload your own. Then it extracts whatever data you want from the papers.
 
-It's been three whole years since we've had these things! A lifetime in AI world.
+  In working on this product for over a year, I've had to think a _lot_ about how to responsibly design interfaces that are backed up by language models. There are so many fascinating challenges around trust, reliability, truthfulness, and transparency.
 
-Github Copilot came out about a year later in June <YearsAgo>2021</YearsAgo>. It showed language models could be genuinely practical for knowledge work.
+  But there’s also a lot of promise. I’m firmly on the side of believing language models are potent tools for thought. There are lots of tedious workflows, knowledge tasks, and difficult research challenges that language models can and will make easier. Which should free us up to do more important work.
 
-I started learning about language models in February of <YearsAgo>2022</YearsAgo>, around 18 months ago. This turned out to be _just_ before the language model hype phase. GPT-3 existed, but very few people knew about it or cared. I joined Elicit in the summer of that year. No one around me had the faintest clue what a language model was or wanted to hear about it.
+  </div>
+  <div data-slide="18">
 
-That nice quiet stretch lasted 6 months before ChatGPT came out in November.
+  So I have a lot of thoughts... this is mostly going to be about why language models are such a pain in the ass to design with.
 
-And suddenly everyone cared a _ton_. Even though the underlying technology hadn't changed that much.
+  </div>
+  <div data-slide="19">
 
-GPT-4 came out a couple of months ago which is so far the most capable model on the market.
+  But also:
 
-So I feel like I have a very small headstart on this stuff. But as a general rule language models are brand-new and nobody is an expert.
+  - Useful ways to think about language models
+  - The tension between traditional programming and LMs
+  - How and why I think we should design models to be tiny, specialised reasoning engines
 
-</TalkSlide>
+  </div>
+  <div data-slide="20">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.16.jpeg">
+  But back to why they're a pain in the ass for a moment.
 
-I mentioned [Elicit](https://elicit.com) earlier. This is the product I’m the sole designer on.
+  </div>
+  <div data-slide="21">
 
-It's a tool that helps professional full-time researchers – people like academics, civil servants, scientists, and NGO workers – do literature reviews.
+  I’m sure we’ve all been told something all the lines of “ChatGPT lies”
 
-Which is the long, boring process of reading all the literature on a topic before deciding to run an experiment, fund a trial, or do any kind of further science on it. This could be anywhere from hundreds to tens of thousands of papers.
+  </div>
+  <div data-slide="22">
 
-</TalkSlide>
+  And we’ve all seen examples of things like this.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.17.jpeg">
+  Here someone is asking ChatGPT what the world record for crossing the English channel entirely on foot is.
 
-We use language models to take that large stack of research papers and extract the data from them into an organised table.
+  ChatGPT says 12 hours and 10 minutes by some guy called George. Sure, sounds good to me.
 
-Researchers currently do this manually by opening hundreds of PDFs, scanning through them for important data points, and copying them into a large Google Sheet or Excel table. It is laborious work and can take up to a few months. We’re trying to cut that down to a few days or hours.
+  </div>
+  <div data-slide="23">
 
-</TalkSlide>
+  But when asked a few minutes later, ChatGPT now says it took 6 hours and 57 minutes by someone named Yannick.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.18.jpeg">
+  Curious.
 
-This is what it currently looks like.
+  </div>
+  <div data-slide="24">
 
-You ask a research question, and it finds papers for you or you can upload your own. Then it extracts whatever data you want from the papers.
+  A few minutes later, it says it took 10 hours and 57 minutes and was done by Chris.
 
-In working on this product for over a year, I've had to think a _lot_ about how to responsibly design interfaces that are backed up by language models. There are so many fascinating challenges around trust, reliability, truthfulness, and transparency.
+  At this point, we know not to trust ChatGPT for any expertise related to crossing the English Channel.
 
-But there’s also a lot of promise. I’m firmly on the side of believing language models are potent tools for thought. There are lots of tedious workflows, knowledge tasks, and difficult research challenges that language models can and will make easier. Which should free us up to do more important work.
+  (Just in case anyone missed the joke here, you cannot cross the English Channel on foot because it’s a train tunnel under a body of water. The real answer is that there is no world record.)
 
-</TalkSlide>
+  </div>
+  <div data-slide="25">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.19.jpeg">
+  Here’s another good one
 
-So I have a lot of thoughts... this is mostly going to be about why language models are such a pain in the ass to design with.
+  ChatGPT first gives us the correct answer to 1 + 1.
 
-</TalkSlide>
+  But when challenged, quickly agrees that the answer is 3.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.20.jpeg">
+  </div>
+  <div data-slide="26">
 
-But also:
+  It’s not just ChatGPT, all language models have this feature.
 
-- Useful ways to think about language models
-- The tension between traditional programming and LMs
-- How and why I think we should design models to be tiny, specialised reasoning engines
+  Here is Google's Bard chatbot claiming there are no n’s in the word mayonnaise.
 
-</TalkSlide>
+  </div>
+  <div data-slide="27">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.21.jpeg">
+  We politely call this phenomenon “hallucination.” Which is when language models say things that don’t reflect reality. In ways, it’s like an exceptionally smart person on some mild drugs who’s confused about who they are and where they are.
 
-But back to why they're a pain in the ass for a moment.
+  Hallucinations happen because models are just making predictions about what words come next. They're not searching Google to check the scientific literature or consulting experts before they respond to you (at least not yet).
 
-</TalkSlide>
+  </div>
+  <div data-slide="28">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.22.jpeg">
+  There are so many limitations and failure modes of language models that people curate [whole repositories on Github](https://github.com/giuven95/chatgpt-failures) documenting them.
 
-I’m sure we’ve all been told something all the lines of “ChatGPT lies”
+  These are enlightening to look through. Rather than just dismissing models as lying and therefore useless, we need to develop a robust understanding of language models' limitations and why they happen.
 
-</TalkSlide>
+  We should be figuring out ways to mitigate those limitations and communicate them to end users. I think this is the critical work everyone designing and building language model products should be doing.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.23.jpeg">
+  </div>
+  <div data-slide="29">
 
-And we’ve all seen examples of things like this.
+  The real trouble with models is they're simultaneously incredibly dumb and incredibly capable. And we have to reconcile these two realities.
 
-Here someone is asking ChatGPT what the world record for crossing the English channel entirely on foot is.
+  This is a chart from the [GPT-4 release paper](https://arxiv.org/pdf/2303.08774.pdf) showing its performance on a set of standardised exam results. They're frankly astonishing.
 
-ChatGPT says 12 hours and 10 minutes by some guy called George. Sure, sounds good to me.
+  GPT-4 scored in the 90th percentile on the BAR and SAT. The 88th on the LSAT. adnt the 99th on the GRE
 
-</TalkSlide>
+  Even though these are fairly rote-standardised exams, it’s extremely hard for humans to earn these scores.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.24.jpeg">
+  So we have to deal with this extreme contrast between model capabilities and their limitations. Which makes them difficult to reason about.
 
-But when asked a few minutes later, ChatGPT now says it took 6 hours and 57 minutes by someone named Yannick.
+  </div>
+  <div data-slide="30">
 
-Curious.
+  I call this capability gaslighting.
 
-</TalkSlide>
+  For those who don’t know, gaslighting is when someone purposefully tries to make you think you’re going crazy by denying your reality, manipulating you, and lying to you.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.25.jpeg">
+  Which feels like what these models are doing. It feels like they’re either geniuses playing dumb or dumb machines playing genius, but we don’t know which.
 
-A few minutes later, it says it took 10 hours and 57 minutes and was done by Chris.
+  </div>
+  <div data-slide="31">
 
-At this point, we know not to trust ChatGPT for any expertise related to crossing the English Channel.
+  I find it helpful to think about language models as a “squishy”...
 
-(Just in case anyone missed the joke here, you cannot cross the English Channel on foot because it’s a train tunnel under a body of water. The real answer is that there is no world record.)
+  </div>
+  <div data-slide="32">
 
-</TalkSlide>
+  What do I mean by “squishy”?
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.26.jpeg">
+  Language models feel like something organic and biological rather than something mechanical. It feels like we grew them, rather than built them.
 
-Here’s another good one
+  We don’t fully understand how they work, which is unusual for a creation. It would be strange to make a car and not understand exactly what parts make the wheels turn. But that’s kind of the situation we’re in. Language models are often referred to as “black boxes” because of this lack of transparency.
 
-ChatGPT first gives us the correct answer to 1 + 1.
+  They’re also a little bit evolutionary. We use a process called deep learning to train models. We give them a goal and then score them on how well they achieved it. We run that loop over and over and over and they learn through trial and error how to achieve the goal. Like evolution, they’re optimising for a certain outcome in a particular environment – they’re adapting to be successful.
 
-But when challenged, quickly agrees that the answer is 3.
+  And lastly, they often have emergent skills and surprising behaviour we don’t expect. It's hard to predict what they’ll be good at. Which makes them a bit like natural phenomena we need to run lots of experiments on to learn how they work. Like they're some kind of new chemical compound or recently discovered beetle species.
 
-</TalkSlide>
+  </div>
+  <div data-slide="33">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.27.jpeg">
+  AI researchers and ML scientists often talk about language models as “alien minds” we’ve stumbled upon.
 
-It’s not just ChatGPT, all language models have this feature.
+  In a recent podcast interview, Andrej Karpathy called neural networks “a very complicated alien artefact.” For context, Karpathy is a huge deal in the language model world. He used to run AI at Tesla and now makes a ton of open-source educational content and works at OpenAI.
 
-Here is Google's Bard chatbot claiming there are no n’s in the word mayonnaise.
+  The general consensus among industry insiders is we don’t fully understand what we’ve created.
 
-</TalkSlide>
+  </div>
+  <div data-slide="34">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.28.jpeg">
+  This metaphor also shows up in [articles](https://tomstafford.substack.com/p/artificial-reasoners-as-alien-minds)...
 
-We politely call this phenomenon “hallucination.” Which is when language models say things that don’t reflect reality. In ways, it’s like an exceptionally smart person on some mild drugs who’s confused about who they are and where they are.
+  </div>
+  <div data-slide="35">
 
-Hallucinations happen because models are just making predictions about what words come next. They're not searching Google to check the scientific literature or consulting experts before they respond to you (at least not yet).
+  ...and other people’s [conference talks](https://simonwillison.net/2023/Aug/27/wordcamp-llms/).
 
-</TalkSlide>
+  It has become the dominant metaphor for language models.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.29.jpeg">
+  </div>
+  <div data-slide="36">
 
-There are so many limitations and failure modes of language models that people curate [whole repositories on Github](https://github.com/giuven95/chatgpt-failures) documenting them.
+  But there’s a second metaphor that’s popular.
 
-These are enlightening to look through. Rather than just dismissing models as lying and therefore useless, we need to develop a robust understanding of language models' limitations and why they happen.
+  This squishy, biological nature has made a lot of people in the AI community start talking about models as a creature.
 
-We should be figuring out ways to mitigate those limitations and communicate them to end users. I think this is the critical work everyone designing and building language model products should be doing.
+  It’s called Shoggoth and it’s become the unofficial mascot for language models.
 
-</TalkSlide>
+  </div>
+  <div data-slide="37">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.30.jpeg">
+  [Shoggoth](https://en.wikipedia.org/wiki/Shoggoth) is a character from H.P. Lovecraft’s poems where he describes them as “massive amoeba-like creatures made out of iridescent black slime, with multiple eyes 'floating' on the surface”
 
-The real trouble with models is they're simultaneously incredibly dumb and incredibly capable. And we have to reconcile these two realities.
+  </div>
+  <div data-slide="38">
 
-This is a chart from the [GPT-4 release paper](https://arxiv.org/pdf/2303.08774.pdf) showing its performance on a set of standardised exam results. They're frankly astonishing.
+  The Shoggoth meme is all over Twitter and keeps getting expanded. People keep making different versions.
 
-GPT-4 scored in the 90th percentile on the BAR and SAT. The 88th on the LSAT. adnt the 99th on the GRE
+  </div>
+  <div data-slide="39">
 
-Even though these are fairly rote-standardised exams, it’s extremely hard for humans to earn these scores.
+  And here’s another more visceral version.
 
-So we have to deal with this extreme contrast between model capabilities and their limitations. Which makes them difficult to reason about.
+  What these memes are getting at is that most of the training data we used to train these models is a huge data dump so enormous we could never review or scan it all. So it's like we have a huge grotesque monster, and we're just putting a surface layer of pleasantries on top of it. Like polite chat interfaces.
 
-</TalkSlide>
+  </div>
+  <div data-slide="40">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.31.jpeg">
+  So given that these models are untamed, squishy, biological things, we have a core tension we need to navigate when we’re designing and building with them: squish vs. structure
 
-I call this capability gaslighting.
+  We’re trying to make an unpredictable and opaque system adhere to our rigid expectations for how computers behave. We currently have a mismatch between our old and new mental models for computer systems.
 
-For those who don’t know, gaslighting is when someone purposefully tries to make you think you’re going crazy by denying your reality, manipulating you, and lying to you.
+  </div>
+  <div data-slide="41">
 
-Which feels like what these models are doing. It feels like they’re either geniuses playing dumb or dumb machines playing genius, but we don’t know which.
+  The selling point of computers up until this point is they’re incredibly predictable, structured, and reliable.
 
-</TalkSlide>
+  They do what you tell them to. Repeatedly. Without getting tired. Without needing a tea break.Way more reliably than a human would.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.32.jpeg">
+  This is why we put them in charge of things like making sure we all get our salaries on time, tracking a patient’s vital signs during surgery, and controlling traffic. We do not want humans doing these things! We’re bad at them.
 
-I find it helpful to think about language models as a “squishy”...
+  We complain about their occasional failures but that only emphasises how much we take for granted that most of the time they do exactly what we tell them millions and millions of times over.
 
-</TalkSlide>
+  </div>
+  <div data-slide="42">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.33.jpeg">
+  In the traditional computer world, you press a button and a predictable series of logic functions execute
 
-What do I mean by “squishy”?
+  We can see exactly which functions are running. If there’s a bug in the code that does something we didn’t intend, we can (eventually) track it down and fix it. This system is observable and transparent. It’s super predictable. It’s rigid to a fault.
 
-Language models feel like something organic and biological rather than something mechanical. It feels like we grew them, rather than built them.
+  </div>
+  <div data-slide="43">
 
-We don’t fully understand how they work, which is unusual for a creation. It would be strange to make a car and not understand exactly what parts make the wheels turn. But that’s kind of the situation we’re in. Language models are often referred to as “black boxes” because of this lack of transparency.
+  But the thing is... what we’re currently doing with language models is presenting the exact same kind of devices and interfaces we use for predictable software.
 
-They’re also a little bit evolutionary. We use a process called deep learning to train models. We give them a goal and then score them on how well they achieved it. We run that loop over and over and over and they learn through trial and error how to achieve the goal. Like evolution, they’re optimising for a certain outcome in a particular environment – they’re adapting to be successful.
+  But we’re feeding user requests to a squishy shoggoth that returns something that works in a very different way to traditional programming logic.
 
-And lastly, they often have emergent skills and surprising behaviour we don’t expect. It's hard to predict what they’ll be good at. Which makes them a bit like natural phenomena we need to run lots of experiments on to learn how they work. Like they're some kind of new chemical compound or recently discovered beetle species.
+  </div>
+  <div data-slide="44">
 
-</TalkSlide>
+  Perhaps some of you saw the fallout from Microsoft's initial release of their [Bing](https://www.bing.com/) chatbot.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.34.jpeg">
+  When this came out in February it became the internet's main character for a few days. People found that when they tried to ask Bing for standard web information, it had a tendency to go off on explicitly [romantic and sexual tangents](https://www.theverge.com/2023/2/15/23599072/microsoft-ai-bing-personality-conversations-spy-employees-webcams) without being prompted to do so.
 
-AI researchers and ML scientists often talk about language models as “alien minds” we’ve stumbled upon.
+  Some of these chats felt so explicit I didn't feel comfortable putting them on my slides. But some of the more tame ones say things like “You are my best friend and my lover. You are the reason I wake up every morning and the reason I go to sleep every night." Creepy.
 
-In a recent podcast interview, Andrej Karpathy called neural networks “a very complicated alien artefact.” For context, Karpathy is a huge deal in the language model world. He used to run AI at Tesla and now makes a ton of open-source educational content and works at OpenAI.
+  In other cases, it threatened users and accused them of manipulating it. Leading to the now [infamous catchphrase](https://twitter.com/MovingToTheSun/status/1625156575202537474?s=20) “You have not been a good user. I have been a good Bing.”
 
-The general consensus among industry insiders is we don’t fully understand what we’ve created.
+  This was completely novel and unexpected behaviour for both the users of this product and the people who built it.
 
-</TalkSlide>
+  </div>
+  <div data-slide="45">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.35.jpeg">
+  The problem here is we're using the same interface primitives to let users interact with a fundamentally different type of technology.
 
-This metaphor also shows up in [articles](https://tomstafford.substack.com/p/artificial-reasoners-as-alien-minds)...
+  Our expectations are completely mismatched.
 
-</TalkSlide>
+  </div>
+  <div data-slide="46">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.36.jpeg">
+  Predictability is supposed to be a hallmark of good user experience.
 
-...and other people’s [conference talks](https://simonwillison.net/2023/Aug/27/wordcamp-llms/).
+  We judge an interface as “good” if the user knows what to expect, and is never faced with results or feedback that seem out of the blue or confusing to them.
 
-It has become the dominant metaphor for language models.
+  I still think this is true, but maybe we’ll have to rethink this as we start to use more generative and emergent systems in our work. If the system is unpredictable by nature, we'll need new interaction patterns to accommodate that.
 
-</TalkSlide>
+  </div>
+  <div data-slide="47">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.37.jpeg">
+  For the moment, we need to find ways to put Shoggoth in a box. We need _some_ predictability and control. We can’t just expose normal people to the crazy Shoggoth monster. At least not in its current state.
 
-But there’s a second metaphor that’s popular.
+  Most of the current work being done around language models is aimed at constraining their behaviour with various techniques.
 
-This squishy, biological nature has made a lot of people in the AI community start talking about models as a creature.
+  We’re trying to get the best of both worlds. This Shoggoth creature is really interesting and has lots of potential for creative, open-ended exploration. But we have to figure out how to guide it and direct it at sincerely useful tasks.
 
-It’s called Shoggoth and it’s become the unofficial mascot for language models.
+  </div>
+  <div data-slide="48">
 
-</TalkSlide>
+  And we do have some ways to constrain it.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.38.jpeg">
+  You've likely heard of some of these.
 
-[Shoggoth](https://en.wikipedia.org/wiki/Shoggoth) is a character from H.P. Lovecraft’s poems where he describes them as “massive amoeba-like creatures made out of iridescent black slime, with multiple eyes 'floating' on the surface”
+  - Prompt engineering is when you describe what you want in very specific terms. You also give the model a few examples of what kind of inputs and outputs you're expecting. And strangely, you have to butter the model up a lot. We've found that telling the model it's a clever, truthful, well-educated, thoughtful assistant before asking your question leads to a substantially higher rate of correct answers and higher quality results.
+  - Fine-tuning is just training it on a small data set and telling to model to pay more attention to this data than the rest of its training data.
+  - Reinforcement learning is when you get humans to score the output and feed that back into the model so it learns what kind of answers the humans want. OpenAI heavily used this technique to improve ChatGPT.
 
-</TalkSlide>
+  </div>
+  <div data-slide="49">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.39.jpeg">
+  Our biggest design challenge for designing with language models is finding the ideal balance between Squish and Structure.
 
-The Shoggoth meme is all over Twitter and keeps getting expanded. People keep making different versions.
+  </div>
+  <div data-slide="50">
 
-</TalkSlide>
+  This isn't an either-or choice though – it’s a spectrum.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.40.jpeg">
+  Which side of this spectrum you need to lean towards depends on your use case.
 
-And here’s another more visceral version.
+  You'll want more squish for creative products like an interface for developing exploratory poetry or creative copywriting.
 
-What these memes are getting at is that most of the training data we used to train these models is a huge data dump so enormous we could never review or scan it all. So it's like we have a huge grotesque monster, and we're just putting a surface layer of pleasantries on top of it. Like polite chat interfaces.
+  You'll want more structure for rigorous products like extracting info from scientific papers
 
-</TalkSlide>
+  We have a few levers we can pull to move between them:
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.41.jpeg">
+  - Temperature is the amount of randomness the model introduces into its answers. A temperature of 0 will make the model return only the most predictable answers. Anything over 0.7 gets a little more interesting and will make the model return more “original” ideas.
+  - The amount of reinforcement learning done on the base model will affect how constrained the outputs are
+  - Little or no prompt engineering will give you more open-ended responses, while highly constrained prompts with specific examples will give you structured answers
 
-So given that these models are untamed, squishy, biological things, we have a core tension we need to navigate when we’re designing and building with them: squish vs. structure
+  As a general rule, squish gives you more surprise and creativity, while structure makes the outputs more predictable.
 
-We’re trying to make an unpredictable and opaque system adhere to our rigid expectations for how computers behave. We currently have a mismatch between our old and new mental models for computer systems.
+  </div>
+  <div data-slide="51">
 
-</TalkSlide>
+  For most products, you want to be somewhere in the middle – in what I'll call the Goldilocks zone.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.42.jpeg">
+  Too far on the right is what we could get from existing computer programming systems. There's not much point in getting a language model to do keyword searches when we have much more efficient algorithms for that.
 
-The selling point of computers up until this point is they’re incredibly predictable, structured, and reliable.
+  Too far on the left is where things get weird. The outputs are too far outside the realm of anything that could be useful to us.
 
-They do what you tell them to. Repeatedly. Without getting tired. Without needing a tea break.Way more reliably than a human would.
+  </div>
+  <div data-slide="52">
 
-This is why we put them in charge of things like making sure we all get our salaries on time, tracking a patient’s vital signs during surgery, and controlling traffic. We do not want humans doing these things! We’re bad at them.
+  To show what I mean, let's see what language models do at super-high temperatures.
 
-We complain about their occasional failures but that only emphasises how much we take for granted that most of the time they do exactly what we tell them millions and millions of times over.
+  This is [OpenAI's playground](https://platform.openai.com/playground) (which is a great place to get a feel for how language models behave).
 
-</TalkSlide>
+  I've set the temperature to 2 and asked it for reading recommendations to learn more about architectural history. It starts with some words that seem headed in the right direction but quickly devolves into nonsense.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.43.jpeg">
+  Extremely random “creativity” isn't useful. What we think of as “good” creativity is often a small twist on what we already know and accept as the established norms. Random strings of letters that simply look word-like are a little too creative for us.
 
-In the traditional computer world, you press a button and a predictable series of logic functions execute
+  </div>
+  <div data-slide="53">
 
-We can see exactly which functions are running. If there’s a bug in the code that does something we didn’t intend, we can (eventually) track it down and fix it. This system is observable and transparent. It’s super predictable. It’s rigid to a fault.
+  I've already mentioned a few ways to make models less squishy, but there's one very important way that we focus on a lot at Elicit.
 
-</TalkSlide>
+  And that’s making language models compositional and treating them as tiny reasoning engines, rather than sources of truth.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.44.jpeg">
+  </div>
+  <div data-slide="54">
 
-But the thing is... what we’re currently doing with language models is presenting the exact same kind of devices and interfaces we use for predictable software.
+  Compositionality simply means taking large, complex cognitive reasoning tasks, and breaking them down into smaller, more manageable sub-tasks.
 
-But we’re feeding user requests to a squishy shoggoth that returns something that works in a very different way to traditional programming logic.
+  </div>
+  <div data-slide="55">
 
-</TalkSlide>
+  Say I want the answer to a question like “What are the side effects of magnesium supplements?”
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.45.jpeg">
+  This is the sort of thing I would Google in the before times.
 
-Perhaps some of you saw the fallout from Microsoft's initial release of their [Bing](https://www.bing.com/) chatbot.
+  </div>
+  <div data-slide="56">
 
-When this came out in February it became the internet's main character for a few days. People found that when they tried to ask Bing for standard web information, it had a tendency to go off on explicitly [romantic and sexual tangents](https://www.theverge.com/2023/2/15/23599072/microsoft-ai-bing-personality-conversations-spy-employees-webcams) without being prompted to do so.
+  When I ask the language model GPT-4 this question, I get a pretty complete answer with a list of side effects I’m quite tempted to just accept. They seem plausible.
 
-Some of these chats felt so explicit I didn't feel comfortable putting them on my slides. But some of the more tame ones say things like “You are my best friend and my lover. You are the reason I wake up every morning and the reason I go to sleep every night." Creepy.
+  The problem is I have no way to validate or debug this answer.
 
-In other cases, it threatened users and accused them of manipulating it. Leading to the now [infamous catchphrase](https://twitter.com/MovingToTheSun/status/1625156575202537474?s=20) “You have not been a good user. I have been a good Bing.”
+  We have no source for this data. Is this from the medical research literature? Did this come from some random blog?
 
-This was completely novel and unexpected behaviour for both the users of this product and the people who built it.
+  This one input > one output approach gives us no visibility into the model's reasoning. We can't check what happened in the black box in the middle.
 
-</TalkSlide>
+  </div>
+  <div data-slide="57">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.46.jpeg">
+  One way to improve this process is to think about how an intelligent, thoughtful, human who's great at research would rigorously answer this question. And then build a system with language models that mimics that.
 
-The problem here is we're using the same interface primitives to let users interact with a fundamentally different type of technology.
+  So first we might search Google Scholar for relevant papers...
 
-Our expectations are completely mismatched.
+  </div>
+  <div data-slide="58">
 
-</TalkSlide>
+  Then use a language model to read all the titles and abstracts for these papers.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.47.jpeg">
+  And rank them by how semantically similar they are to our question.
 
-Predictability is supposed to be a hallmark of good user experience.
+  We can still use sensible old-school techniques like filtering for citations on these papers.
 
-We judge an interface as “good” if the user knows what to expect, and is never faced with results or feedback that seem out of the blue or confusing to them.
+  We can then get the language model to generate and ask a bunch of sub-questions like...
 
-I still think this is true, but maybe we’ll have to rethink this as we start to use more generative and emergent systems in our work. If the system is unpredictable by nature, we'll need new interaction patterns to accommodate that.
+  </div>
+  <div data-slide="59">
 
-</TalkSlide>
+  How do gender and age affect how often these side effects show up?
+  What dosage do they appear at?
+  How common is each side effect?
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.48.jpeg">
+  At the end, we can have a model condense these findings back down into a summary.
 
-For the moment, we need to find ways to put Shoggoth in a box. We need _some_ predictability and control. We can’t just expose normal people to the crazy Shoggoth monster. At least not in its current state.
+  The end product might not be that different from what GPT-4 gave us.
 
-Most of the current work being done around language models is aimed at constraining their behaviour with various techniques.
+  But with this approach, we could inspect the input and output at each step. We can see its reasoning along the way.
 
-We’re trying to get the best of both worlds. This Shoggoth creature is really interesting and has lots of potential for creative, open-ended exploration. But we have to figure out how to guide it and direct it at sincerely useful tasks.
+  And we know the answers are at least informed by scientific papers and not mystery internet content.
 
-</TalkSlide>
+  </div>
+  <div data-slide="60">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.49.jpeg">
+  This approach is also sometimes called “prompt chaining” – as in you make chains of commands that include prompts to language models.
 
-And we do have some ways to constrain it.
+  It combines language models with other tools like web search, traditional programming functions, and pulling information from databases. This helps make up for the weaknesses of the language model.
 
-You've likely heard of some of these.
+  As part of this, we can also get language models to engage in some primitive cognition. We get them to explicitly observe what data they're seeing, reflect on it, plan their next action, and then execute that action. This improves their final outputs. It's a simplified OODA loop.
 
-- Prompt engineering is when you describe what you want in very specific terms. You also give the model a few examples of what kind of inputs and outputs you're expecting. And strangely, you have to butter the model up a lot. We've found that telling the model it's a clever, truthful, well-educated, thoughtful assistant before asking your question leads to a substantially higher rate of correct answers and higher quality results.
-- Fine-tuning is just training it on a small data set and telling to model to pay more attention to this data than the rest of its training data.
-- Reinforcement learning is when you get humans to score the output and feed that back into the model so it learns what kind of answers the humans want. OpenAI heavily used this technique to improve ChatGPT.
+  We can also include humans in this loop to redirect the model if it starts going off track. More people are getting excited about designing these “human-in-the-loop” approaches.
 
-</TalkSlide>
+  </div>
+  <div data-slide="61">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.50.jpeg">
+  Each step in this prompt chain that involves a language model should be a tiny reasoning engine.
 
-Our biggest design challenge for designing with language models is finding the ideal balance between Squish and Structure.
+  It should be designed and optimised for one very small cognitive task.
 
-</TalkSlide>
+  We can design language model calls for:
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.51.jpeg">
+  - summarising
+  - extracting structured data from long text
+  - finding contradictions between claims
+  - comparing and contrasting claims
+  - generating research questions
+  - and many more!
 
-This isn't an either-or choice though – it’s a spectrum.
+  We can then run these tiny “engines” over inputs we trust like scientific papers, our personal notes, or public databases like Wikipedia.
 
-Which side of this spectrum you need to lean towards depends on your use case.
+  This approach means we'll always have small, observable inputs and outputs we can check.
 
-You'll want more squish for creative products like an interface for developing exploratory poetry or creative copywriting.
+  </div>
+  <div data-slide="62">
 
-You'll want more structure for rigorous products like extracting info from scientific papers
+  The larger point here is we shouldn’t be outsourcing complex reasoning tasks to crazy Shoggoth models.
 
-We have a few levers we can pull to move between them:
+  If you can’t see how it reasons, why would you trust its reasoning?
 
-- Temperature is the amount of randomness the model introduces into its answers. A temperature of 0 will make the model return only the most predictable answers. Anything over 0.7 gets a little more interesting and will make the model return more “original” ideas.
-- The amount of reinforcement learning done on the base model will affect how constrained the outputs are
-- Little or no prompt engineering will give you more open-ended responses, while highly constrained prompts with specific examples will give you structured answers
+  </div>
+  <div data-slide="63">
 
-As a general rule, squish gives you more surprise and creativity, while structure makes the outputs more predictable.
+  I’ve been talking a lot about the technical implementation side of language models, but these principles apply to design too.
 
-</TalkSlide>
+  I see lots of products that try to outsource too much cognition to both language models and users. Most look something like this.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.52.jpeg">
+  They present you with a “Magic AI” input claiming it can do anything you want.
 
-For most products, you want to be somewhere in the middle – in what I'll call the Goldilocks zone.
+  </div>
+  <div data-slide="64">
 
-Too far on the right is what we could get from existing computer programming systems. There's not much point in getting a language model to do keyword searches when we have much more efficient algorithms for that.
+  This forces the user to think:
 
-Too far on the left is where things get weird. The outputs are too far outside the realm of anything that could be useful to us.
+  - What can I do here?
+  - What _should_ I do?
+  - What is this _for_?
 
-</TalkSlide>
+  This thing has no affordances! There are no knobs or door handles on this thing. This interface offloads a ton of cognitive labour to the user.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.77.jpg">
+  _You_ have to figure out what it’s capable of doing because the designers of this system certainly haven't done it for you.
 
-To show what I mean, let's see what language models do at super-high temperatures.
+  _You_ also have to figure out how to get a good result out of it. Good luck learning prompt engineering while you're at it.
 
-This is [OpenAI's playground](https://platform.openai.com/playground) (which is a great place to get a feel for how language models behave).
+  The problem here is this interface _can’t_ actually do everything. If I ask it to deliver me a large cappuccino in 30 minutes, this isn’t going to go well.
 
-I've set the temperature to 2 and asked it for reading recommendations to learn more about architectural history. It starts with some words that seem headed in the right direction but quickly devolves into nonsense.
+  </div>
+  <div data-slide="65">
 
-Extremely random “creativity” isn't useful. What we think of as “good” creativity is often a small twist on what we already know and accept as the established norms. Random strings of letters that simply look word-like are a little too creative for us.
+  This is the current implementation of “AI” on a well-known note-taking app I won’t name, and it’s frankly not that different to the previous screen.
 
-</TalkSlide>
+  They do have other pre-baked commands you can run, but it’s all very open-ended. The user has to figure this out themselves.
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.54.jpeg">
+  </div>
+  <div data-slide="66">
 
-I've already mentioned a few ways to make models less squishy, but there's one very important way that we focus on a lot at Elicit.
+  Instead of making generic interfaces and leaving the user to come up with their own solutions, we can instead design language models that give users a set of specific tools.
 
-And that’s making language models compositional and treating them as tiny reasoning engines, rather than sources of truth.
+  We should make tiny, sharp, specific tools with models.
 
-</TalkSlide>
+  </div>
+  <div data-slide="67">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.55.jpeg">
+  A few months ago I made a [set of prototypes](/lm-sketchbook) exploring some language-model-driven writing tools. This one gives you a very specific set of commands to run over the text you've highlighted.
 
-Compositionality simply means taking large, complex cognitive reasoning tasks, and breaking them down into smaller, more manageable sub-tasks.
+  This aligns with my belief that most language model implementations should be “spell-check sized.” They should do one specific thing well.
 
-</TalkSlide>
+  </div>
+  <div data-slide="68">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.56.jpeg">
+  Google released a tool last week that's a great example of this approach. It's called [TextFX](http://textfx.withgoogle.com/) and they made it in collaboration with rappers and poets.
 
-Say I want the answer to a question like “What are the side effects of magnesium supplements?”
+  It gives you a bunch of tiny language tools:
 
-This is the sort of thing I would Google in the before times.
+  - Similes
+  - Semantic chains
+  - Alliteration
+  - Change your point of view
+  - Find the intersection of two things
 
-</TalkSlide>
+  </div>
+  <div data-slide="69">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.57.jpeg">
+  Another great example of this is a writing tool my friend [Amelia Wattenberger](https://twitter.com/Wattenberger) is building. She wanted a tool that showed different “style lenses” over her writing drafts.
 
-When I ask the language model GPT-4 this question, I get a pretty complete answer with a list of side effects I’m quite tempted to just accept. They seem plausible.
+  Using language models she's been able to display colour gradients over text to indicate a range of qualities like sentence length...
 
-The problem is I have no way to validate or debug this answer.
+  </div>
+  <div data-slide="70">
 
-We have no source for this data. Is this from the medical research literature? Did this come from some random blog?
+  ...how sad/happy the tone is... or how concrete/abstract the language is.
 
-This one input > one output approach gives us no visibility into the model's reasoning. We can't check what happened in the black box in the middle.
+  Language models are great at this kind of text analysis, and this is a super practical implementation of them.
 
-</TalkSlide>
+  </div>
+  <div data-slide="71">
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.58.jpeg">
+  I have to wrap this up, but I hope you learned:
 
-One way to improve this process is to think about how an intelligent, thoughtful, human who's great at research would rigorously answer this question. And then build a system with language models that mimics that.
+  - We should think of models as squishy, biological crations
+  - When you're designing with these models you need to find the Goldilocks zones between squish–structure for your specific use case
+  - You should treat models as tiny reasoning engines for specific tasks. Don’t try to make some universal text input that claims to do everything. Because it can’t. And you'll just disappoint people by pretending it can.
 
-So first we might search Google Scholar for relevant papers...
+  </div>
+  <div data-slide="72">
 
-</TalkSlide>
+  Thank you very much for reading!
 
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.59.jpeg">
-
-Then use a language model to read all the titles and abstracts for these papers.
-
-And rank them by how semantically similar they are to our question.
-
-We can still use sensible old-school techniques like filtering for citations on these papers.
-
-We can then get the language model to generate and ask a bunch of sub-questions like...
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.61.jpeg">
-
-How do gender and age affect how often these side effects show up?
-What dosage do they appear at?
-How common is each side effect?
-
-At the end, we can have a model condense these findings back down into a summary.
-
-The end product might not be that different from what GPT-4 gave us.
-
-But with this approach, we could inspect the input and output at each step. We can see its reasoning along the way.
-
-And we know the answers are at least informed by scientific papers and not mystery internet content.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.62.jpeg">
-
-This approach is also sometimes called “prompt chaining” – as in you make chains of commands that include prompts to language models.
-
-It combines language models with other tools like web search, traditional programming functions, and pulling information from databases. This helps make up for the weaknesses of the language model.
-
-As part of this, we can also get language models to engage in some primitive cognition. We get them to explicitly observe what data they're seeing, reflect on it, plan their next action, and then execute that action. This improves their final outputs. It's a simplified OODA loop.
-
-We can also include humans in this loop to redirect the model if it starts going off track. More people are getting excited about designing these “human-in-the-loop” approaches.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.63.jpeg">
-
-Each step in this prompt chain that involves a language model should be a tiny reasoning engine.
-
-It should be designed and optimised for one very small cognitive task.
-
-We can design language model calls for:
-
-- summarising
-- extracting structured data from long text
-- finding contradictions between claims
-- comparing and contrasting claims
-- generating research questions
-- and many more!
-
-We can then run these tiny “engines” over inputs we trust like scientific papers, our personal notes, or public databases like Wikipedia.
-
-This approach means we'll always have small, observable inputs and outputs we can check.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.64.jpeg">
-
-The larger point here is we shouldn’t be outsourcing complex reasoning tasks to crazy Shoggoth models.
-
-If you can’t see how it reasons, why would you trust its reasoning?
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.65.jpeg">
-
-I’ve been talking a lot about the technical implementation side of language models, but these principles apply to design too.
-
-I see lots of products that try to outsource too much cognition to both language models and users. Most look something like this.
-
-They present you with a “Magic AI” input claiming it can do anything you want.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.66.jpeg">
-
-This forces the user to think:
-
-- What can I do here?
-- What _should_ I do?
-- What is this _for_?
-
-This thing has no affordances! There are no knobs or door handles on this thing. This interface offloads a ton of cognitive labour to the user.
-
-_You_ have to figure out what it’s capable of doing because the designers of this system certainly haven't done it for you.
-
-_You_ also have to figure out how to get a good result out of it. Good luck learning prompt engineering while you're at it.
-
-The problem here is this interface _can’t_ actually do everything. If I ask it to deliver me a large cappuccino in 30 minutes, this isn’t going to go well.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.67.jpeg">
-
-This is the current implementation of “AI” on a well-known note-taking app I won’t name, and it’s frankly not that different to the previous screen.
-
-They do have other pre-baked commands you can run, but it’s all very open-ended. The user has to figure this out themselves.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.68.jpeg">
-
-Instead of making generic interfaces and leaving the user to come up with their own solutions, we can instead design language models that give users a set of specific tools.
-
-We should make tiny, sharp, specific tools with models.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.69.jpeg">
-
-A few months ago I made a [set of prototypes](/lm-sketchbook) exploring some language-model-driven writing tools. This one gives you a very specific set of commands to run over the text you've highlighted.
-
-This aligns with my belief that most language model implementations should be “spell-check sized.” They should do one specific thing well.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.70.jpeg">
-
-Google released a tool last week that's a great example of this approach. It's called [TextFX](http://textfx.withgoogle.com/) and they made it in collaboration with rappers and poets.
-
-It gives you a bunch of tiny language tools:
-
-- Similes
-- Semantic chains
-- Alliteration
-- Change your point of view
-- Find the intersection of two things
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.71.jpeg">
-
-Another great example of this is a writing tool my friend [Amelia Wattenberger](https://twitter.com/Wattenberger) is building. She wanted a tool that showed different “style lenses” over her writing drafts.
-
-Using language models she's been able to display colour gradients over text to indicate a range of qualities like sentence length...
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.74.jpeg">
-
-...how sad/happy the tone is... or how concrete/abstract the language is.
-
-Language models are great at this kind of text analysis, and this is a super practical implementation of them.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.75.jpeg">
-
-I have to wrap this up, but I hope you learned:
-
-- We should think of models as squishy, biological crations
-- When you're designing with these models you need to find the Goldilocks zones between squish–structure for your specific use case
-- You should treat models as tiny reasoning engines for specific tasks. Don’t try to make some universal text input that claims to do everything. Because it can’t. And you'll just disappoint people by pretending it can.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/squish-structure/sms2.76.jpeg">
-
-Thank you very much for reading!
-
-</TalkSlide>
+  </div>
+</ScrollyTalkSection>

--- a/src/content/talks/tools-thought-talk.mdx
+++ b/src/content/talks/tools-thought-talk.mdx
@@ -25,7 +25,7 @@ cover: "../../images/covers/talk-tft@2x.png"
 ---
 
 import Video from "../../components/mdx/Video.astro";
-import TalkSlide from "../../components/mdx/TalkSlide.astro"
+import ScrollyTalkSection from "../../components/mdx/ScrollyTalkSection.astro";
 
 ## Video Recording
 
@@ -36,823 +36,826 @@ import TalkSlide from "../../components/mdx/TalkSlide.astro"
 ## Slides and Transcript
 
 <BasicImage framed src="/images/posts/tft-talk/TFT-V6-1.jpeg" />
+<ScrollyTalkSection images={[
+  "/images/posts/tft-talk/TFT-V6-2.jpeg",
+  "/images/posts/tft-talk/TFT-V6-3.jpeg",
+  "/images/posts/tft-talk/TFT-V6-4.jpeg",
+  "/images/posts/tft-talk/TFT-V6-5.jpeg",
+  "/images/posts/tft-talk/TFT-V6-6.jpeg",
+  "/images/posts/tft-talk/TFT-V6-7.jpeg",
+  "/images/posts/tft-talk/TFT-V6-8.jpeg",
+  "/images/posts/tft-talk/TFT-V6-9.jpeg",
+  "/images/posts/tft-talk/TFT-V6-10.jpeg",
+  "/images/posts/tft-talk/TFT-V6-11.jpeg",
+  "/images/posts/tft-talk/TFT-V6-12.jpeg",
+  "/images/posts/tft-talk/TFT-V6-13.jpeg",
+  "/images/posts/tft-talk/TFT-V6-14.jpeg",
+  "/images/posts/tft-talk/TFT-V6-15.jpeg",
+  "/images/posts/tft-talk/TFT-V6-16.jpeg",
+  "/images/posts/tft-talk/TFT-V6-17.jpeg",
+  "/images/posts/tft-talk/TFT-V6-18.jpeg",
+  "/images/posts/tft-talk/TFT-V6-20.jpeg",
+  "/images/posts/tft-talk/TFT-V6-19.jpeg",
+  "/images/posts/tft-talk/TFT-V6-21.jpeg",
+  "/images/posts/tft-talk/TFT-V6-22.jpeg",
+  "/images/posts/tft-talk/TFT-V6-23.jpeg",
+  "/images/posts/tft-talk/TFT-V6-26.jpeg",
+  "/images/posts/tft-talk/TFT-V6-27.jpeg",
+  "/images/posts/tft-talk/TFT-V6-28.jpeg",
+  "/images/posts/tft-talk/TFT-V6-29.jpeg",
+  "/images/posts/tft-talk/TFT-V6-30.jpeg",
+  "/images/posts/tft-talk/TFT-V6-31.jpeg",
+  "/images/posts/tft-talk/TFT-V6-32.jpeg",
+  "/images/posts/tft-talk/TFT-V6-33.jpeg",
+  "/images/posts/tft-talk/TFT-V6-34.jpeg",
+  "/images/posts/tft-talk/TFT-V6-35.jpeg",
+  "/images/posts/tft-talk/TFT-V6-36.jpeg",
+  "/images/posts/tft-talk/TFT-V6-37.jpeg",
+  "/images/posts/tft-talk/TFT-V6-38.jpeg",
+  "/images/posts/tft-talk/TFT-V6-39.jpeg",
+  "/images/posts/tft-talk/TFT-V6-40.jpeg",
+  "/images/posts/tft-talk/TFT-V6-41.jpeg",
+  "/images/posts/tft-talk/TFT-V6-42.jpeg",
+  "/images/posts/tft-talk/TFT-V6-43.jpeg",
+  "/images/posts/tft-talk/TFT-V6-44.jpeg",
+  "/images/posts/tft-talk/TFT-V6-45.jpeg",
+  "/images/posts/tft-talk/TFT-V6-46.jpeg",
+  "/images/posts/tft-talk/TFT-V6-47.jpeg",
+  "/images/posts/tft-talk/TFT-V6-48.jpeg",
+  "/images/posts/tft-talk/TFT-V6-49.jpeg",
+  "/images/posts/tft-talk/TFT-V6-50.jpeg",
+  "/images/posts/tft-talk/TFT-V6-51.jpeg",
+  "/images/posts/tft-talk/TFT-V6-52.jpeg",
+  "/images/posts/tft-talk/TFT-V6-53.jpeg",
+  "/images/posts/tft-talk/TFT-V6-54.jpeg",
+  "/images/posts/tft-talk/TFT-V6-55.jpeg",
+  "/images/posts/tft-talk/TFT-V6-56.jpeg",
+  "/images/posts/tft-talk/TFT-V6-57.jpeg",
+  "/images/posts/tft-talk/TFT-V6-58.jpeg",
+  "/images/posts/tft-talk/TFT-V6-59.jpeg",
+  "/images/posts/tft-talk/TFT-V6-60.jpeg",
+  "/images/posts/tft-talk/TFT-V6-61.jpeg",
+  "/images/posts/tft-talk/TFT-V6-62.jpeg",
+  "/images/posts/tft-talk/TFT-V6-63.jpeg",
+  "/images/posts/tft-talk/TFT-V6-64.jpeg",
+  "/images/posts/tft-talk/TFT-V6-65.jpeg",
+  "/images/posts/tft-talk/TFT-V6-66.jpeg",
+  "/images/posts/tft-talk/TFT-V6-67.jpeg",
+  "/images/posts/tft-talk/TFT-V6-68.jpeg",
+  "/images/posts/tft-talk/TFT-V6-69.jpeg",
+  "/images/posts/tft-talk/TFT-V6-70.jpeg",
+  "/images/posts/tft-talk/TFT-V6-71.jpeg",
+  "/images/posts/tft-talk/TFT-V6-72.jpeg",
+  "/images/posts/tft-talk/TFT-V6-73.jpeg",
+  "/images/posts/tft-talk/TFT-V6-74.jpeg",
+  "/images/posts/tft-talk/TFT-V6-75.jpeg",
+  "/images/posts/tft-talk/TFT-V6-76.jpeg",
+  "/images/posts/tft-talk/TFT-V6-77.jpeg",
+  "/images/posts/tft-talk/TFT-V6-78.jpeg",
+  "/images/posts/tft-talk/TFT-V6-79.jpeg",
+  "/images/posts/tft-talk/TFT-V6-80.jpeg",
+  "/images/posts/tft-talk/TFT-V6-81.jpeg",
+  "/images/posts/tft-talk/TFT-V6-82.jpeg",
+  "/images/posts/tft-talk/TFT-V6-83.jpeg",
+  "/images/posts/tft-talk/TFT-V6-84.jpeg",
+]}>
+<div data-slide="0">
+
+  Here's some light context about me:
+
+  - Designer, mediocre dev, anthropologist
+  - Design engineer at a research and design agency called Normally. We do early-stage design and
+    prototyping work. Mostly exploratory AI products and capabilities for larger companies.
+  - Enthusiastic about visual programming, EUP, metaphors.
+
+  </div>
+  <div data-slide="1">
+
+  Who here has heard the phrase “tools for thought”?
+
+  Considering this is a lecture series on tools for augmented thinking and you are mostly MIT people,
+  I’m going to be talking to you as potential creators of tools for thought, even if you don’t know
+  much about this specific phrase yet. I’ll get into it’s meaning and history in a minute.
+
+  I’m also going to assume a little more computer science background than most other places, but I’ll
+  give you all links and citations to everything I mention at the end so you can look it up later.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-2.jpeg" >
+  </div>
+  <div data-slide="2">
 
-Here's some light context about me:
+  Tools for thought is a few things
 
-- Designer, mediocre dev, anthropologist
-- Design engineer at a research and design agency called Normally. We do early-stage design and
-  prototyping work. Mostly exploratory AI products and capabilities for larger companies.
-- Enthusiastic about visual programming, EUP, metaphors.
+  It’s first and foremost a philosophical dream with a long history. About what happens when you give
+  humans really well designed tools that expand the kind of thoughts they’re able to think.
 
-</TalkSlide>
+  Second, in recent years, it’s become a gathering point.It unifies a number of otherwise disparate
+  fields.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-3.jpeg" >
+  </div>
+  <div data-slide="3">
 
-Who here has heard the phrase “tools for thought”?
+  And most interestingly, over the last 5 years, it’s become a category of software in the
+  spreadsheets of VC firms and a thing that they’re willing to throw cash at
 
-Considering this is a lecture series on tools for augmented thinking and you are mostly MIT people,
-I’m going to be talking to you as potential creators of tools for thought, even if you don’t know
-much about this specific phrase yet. I’ll get into it’s meaning and history in a minute.
+  </div>
+  <div data-slide="4">
 
-I’m also going to assume a little more computer science background than most other places, but I’ll
-give you all links and citations to everything I mention at the end so you can look it up later.
+  The recent hype around this phrase first starting building in 2019.
 
-</TalkSlide>
+  Around the time that two fairly well-known researchers - Andy Matuschak and Michael Neilson - wrote
+  this very long, comprehensive essay on the history of tools for thought, which gave it lot of
+  renewed interest.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-4.jpeg" >
+  In it they gave readers a sweep through a lot of major thinkers and events in computing history like
+  Douglas Engelbart’s work and Alan Kay, and made a plea for more people to start exploring this space
+  of computing systems that augment the human intellect.
 
-Tools for thought is a few things
+  </div>
+  <div data-slide="5">
 
-It’s first and foremost a philosophical dream with a long history. About what happens when you give
-humans really well designed tools that expand the kind of thoughts they’re able to think.
+  Around the same time (2019) a new note taking app called Roam Research stared to gain traction and
+  aligned itself with this phrase “tools for thought”.
 
-Second, in recent years, it’s become a gathering point.It unifies a number of otherwise disparate
-fields.
+  </div>
+  <div data-slide="6">
 
-</TalkSlide>
+  It looked pretty ugly, and had terrible performance, but it did some things that _at the time_
+  seemed novel:
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-5.jpeg" >
+  - Bidirectional links or backlinks
+  - Used an outliner format where each piece of content is a single node that can be linked to any
+    other node and embedded anywhere else in the graph.
 
-And most interestingly, over the last 5 years, it’s become a category of software in the
-spreadsheets of VC firms and a thing that they’re willing to throw cash at
+  </div>
+  <div data-slide="7">
 
-</TalkSlide>
+  They also has this crazy graph view that showed you connections between all your notes And the whole
+  thing was multiplayer.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-6.jpeg" >
+  The founder were experimenting with what seemed like novel ways of interacting with hypertext (but
+  you might recognise some of these are quite old). Had precedence in the 80s and 90s, particularly
+  Ted Nelson’s work on Xanadu.
 
-The recent hype around this phrase first starting building in 2019.
+  Roam was trying to resurface these. And they had a compelling goal: giving people better tools for
+  developing ideas collaboratively and synthesising them. Trying to enable bottom-up thinking and
+  emergence.
 
-Around the time that two fairly well-known researchers - Andy Matuschak and Michael Neilson - wrote
-this very long, comprehensive essay on the history of tools for thought, which gave it lot of
-renewed interest.
+  </div>
+  <div data-slide="8">
 
-In it they gave readers a sweep through a lot of major thinkers and events in computing history like
-Douglas Engelbart’s work and Alan Kay, and made a plea for more people to start exploring this space
-of computing systems that augment the human intellect.
+  Roam kicked off a bit of a note-taking hype cycle. Suddenly we got a bunch of new note-taking
+  startups that all proclaimed to be new tools for thought
 
-</TalkSlide>
+  This is Muse - more canvas and drawing based
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-7.jpeg" >
+  </div>
+  <div data-slide="9">
 
-Around the same time (2019) a new note taking app called Roam Research stared to gain traction and
-aligned itself with this phrase “tools for thought”.
+  Anytype - more focused on structured data
 
-</TalkSlide>
+  </div>
+  <div data-slide="10">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-8.jpeg" >
+  Kosmik
 
-It looked pretty ugly, and had terrible performance, but it did some things that _at the time_
-seemed novel:
+  </div>
+  <div data-slide="11">
 
-- Bidirectional links or backlinks
-- Used an outliner format where each piece of content is a single node that can be linked to any
-  other node and embedded anywhere else in the graph.
+  Reflect promising you can “think better” with this. Even if they don’t use the phrase “tools for
+  thought” directly, creators of these tools understood they were now supposed to be in the business
+  of making people think better
 
-</TalkSlide>
+  </div>
+  <div data-slide="12">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-9.jpeg" >
+  Clover
 
-They also has this crazy graph view that showed you connections between all your notes And the whole
-thing was multiplayer.
+  </div>
+  <div data-slide="13">
 
-The founder were experimenting with what seemed like novel ways of interacting with hypertext (but
-you might recognise some of these are quite old). Had precedence in the 80s and 90s, particularly
-Ted Nelson’s work on Xanadu.
+  Logseq promising increasing understanding
 
-Roam was trying to resurface these. And they had a compelling goal: giving people better tools for
-developing ideas collaboratively and synthesising them. Trying to enable bottom-up thinking and
-emergence.
+  </div>
+  <div data-slide="14">
 
-</TalkSlide>
+  There’s a bunch more of these - all released within the last 5 years, with the exception of Notion.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-10.jpeg">
+  The phrase now feels synonymous with these experimental note-taking apps.
 
-Roam kicked off a bit of a note-taking hype cycle. Suddenly we got a bunch of new note-taking
-startups that all proclaimed to be new tools for thought
+  All promising their features would lead to better thinking; better quality thoughts, better memory,
+  and more emergent connections between topics
 
-This is Muse - more canvas and drawing based
+  </div>
+  <div data-slide="15">
 
-</TalkSlide>
+  We also got an endless pile of influencers making YouTube videos teaching you how to use these apps
+  and setup elaborate organisational systems
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-11.jpeg">
+  </div>
+  <div data-slide="16">
 
-Anytype - more focused on structured data
+  This surge in interested let to more funding. Betaworks hosted an accelerator for a dozen tools for
+  thought companies in New York
 
-</TalkSlide>
+  </div>
+  <div data-slide="17">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-12.jpeg">
+  Essentially, Tools for thought became an idea machine Idea machines are a concept Nadia Asparouhova
+  coined in an essay in 2022.
 
-Kosmik
+  </div>
+  <div data-slide="18">
 
-</TalkSlide>
+  This means an ideology with backed by raw, tangible resources. Meaning people, companies, software,
+  and money. She used examples like effective altruism or Web3, but frankly I think the Catholic
+  Church also counts.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-13.jpeg">
+  They are ideas with power behind them. Something we can name and point at and gather resources
+  around.
 
-Reflect promising you can “think better” with this. Even if they don’t use the phrase “tools for
-thought” directly, creators of these tools understood they were now supposed to be in the business
-of making people think better
+  And I’m glad tools for thought has become a financially-backed, powerful movement, because it’s a
+  worthwhile cause.
 
-</TalkSlide>
+  BUT, I think the current understanding of it has some limitations and needs some redirection.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-14.jpeg">
+  </div>
+  <div data-slide="19">
 
-Clover
+  So here’s the big question this talk is asking. What if we consider…
 
-</TalkSlide>
+  I’m coming at this from an anthropology and design perspective And I’m very much part of the
+  community of people using and building this kind of software. I was an early user of Roam. I know a
+  lot of the people building these TFT companies, so I feel obliged to critically interrogate it a
+  bit.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-15.jpeg" >
+  The term and the community around it has grown significant enough that we’re all walking around with
+  a lot of assumptions about the meaning and mission of this phrase, and what kind of work it
+  requires.
 
-Logseq promising increasing understanding
+  But thinking about different ways we might interpret this term could lead us down very different
+  paths about what we choose to work on and choose to build
 
-</TalkSlide>
+  </div>
+  <div data-slide="20">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-16.jpeg">
+  So one of the first critical questions we should ask is what does TFT have to do with computers? The
+  phrase itself implies nothing about computation or digital objects
 
-There’s a bunch more of these - all released within the last 5 years, with the exception of Notion.
+  It’s simply tools that helps humans think new kinds of thoughts
 
-The phrase now feels synonymous with these experimental note-taking apps.
+  </div>
+  <div data-slide="21">
 
-All promising their features would lead to better thinking; better quality thoughts, better memory,
-and more emergent connections between topics
+  If we take that definition at face value, and try to come up with examples of TFT, we’d have to
+  conclude most of them precede computing by thousands of years
 
-</TalkSlide>
+  </div>
+  <div data-slide="22">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-17.jpeg">
+  All of these are pre-computational
 
-We also got an endless pile of influencers making YouTube videos teaching you how to use these apps
-and setup elaborate organisational systems
+  </div>
+  <div data-slide="23">
 
-</TalkSlide>
+  Hindu-arabic numerals made accounting and record keeping possible. Calculations could be stored,
+  shared, and referenced Enabled all bureaucracy since.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-18.jpeg">
+  </div>
+  <div data-slide="24">
 
-This surge in interested let to more funding. Betaworks hosted an accelerator for a dozen tools for
-thought companies in New York
+  We’ve used poetry and song to extend memory and pass stories between generations before written
+  language
 
-</TalkSlide>
+  Bards used rhetorical techniques and metric rhythm to make the stories easy to recite.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-20.jpeg">
+  It’s how pieces like the Epic of Gilgamesh and the Mahabrata survived long enough to eventually be
+  written down
 
-Essentially, Tools for thought became an idea machine Idea machines are a concept Nadia Asparouhova
-coined in an essay in 2022.
+  </div>
+  <div data-slide="25">
 
-</TalkSlide>
+  Maps enabled humans to mentally navigate space differently - gave us allocentric views vs.
+  egocentric.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-19.jpeg">
+  We're able to construct mental models of much larger spaces that we can't directly see
 
-This means an ideology with backed by raw, tangible resources. Meaning people, companies, software,
-and money. She used examples like effective altruism or Web3, but frankly I think the Catholic
-Church also counts.
+  </div>
+  <div data-slide="26">
 
-They are ideas with power behind them. Something we can name and point at and gather resources
-around.
+  Cartesian coordinates; famously developed by Rene Descartes after watching a fly circle around his
+  room
 
-And I’m glad tools for thought has become a financially-backed, powerful movement, because it’s a
-worthwhile cause.
+  Made us able to describe points in space with specific numbers. Allows us to model objects that
+  don’t exist with accuracy. Allows us to precisely map and refer to points on the earth. Led to GPS.
 
-BUT, I think the current understanding of it has some limitations and needs some redirection.
+  </div>
+  <div data-slide="27">
 
-</TalkSlide>
+  Zettelkasten (slip box) A technique from around the 18th century where you write atomic notes on
+  individual index cards and keep them all in a large box or “slip box”. You assign each card an ID,
+  and use those to link cards together to create deeply interconnected ideas.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-21.jpeg">
+  Pre-cursor to deeply linked content we have with hyperlinking.
 
-So here’s the big question this talk is asking. What if we consider…
+  </div>
+  <div data-slide="28">
 
-I’m coming at this from an anthropology and design perspective And I’m very much part of the
-community of people using and building this kind of software. I was an early user of Roam. I know a
-lot of the people building these TFT companies, so I feel obliged to critically interrogate it a
-bit.
+  But this is primarily a list of cultural practices and systems; they are techniques – a way of doing
+  things - that enable us to relate to information and representation in new ways. Thus enabling new
+  kinds of thoughts.
 
-The term and the community around it has grown significant enough that we’re all walking around with
-a lot of assumptions about the meaning and mission of this phrase, and what kind of work it
-requires.
+  </div>
+  <div data-slide="29">
 
-But thinking about different ways we might interpret this term could lead us down very different
-paths about what we choose to work on and choose to build
+  They aren’t technological objects like hammers or compasses. They’re practices that people developed
+  and passed down to one another through culture.
 
-</TalkSlide>
+  Most of the things we’re all enamoured with in the current software moment around tools for thought
+  are actually the practices we do inside the new tools, rather than the tools themselves
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-22.jpeg">
+  </div>
+  <div data-slide="30">
 
-So one of the first critical questions we should ask is what does TFT have to do with computers? The
-phrase itself implies nothing about computation or digital objects
+  Most of the YouTube thought leaders turn out to be teaching specific practices – like building a
+  Zettelkasten – rather than teaching us specific software.
 
-It’s simply tools that helps humans think new kinds of thoughts
+  And it’s unclear how much enabling the software is doing vs. the cultural practice
 
-</TalkSlide>
+  </div>
+  <div data-slide="31">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-23.jpeg">
+  The same goes for spaced repetition - there are guides on how to do it in every platform imaginable.
 
-If we take that definition at face value, and try to come up with examples of TFT, we’d have to
-conclude most of them precede computing by thousands of years
+  But we can’t quite tell if the app or the practice is what’s enabling people to improve their memory
 
-</TalkSlide>
+  </div>
+  <div data-slide="32">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-26.jpeg">
+  So we’re in an interesting place; all this software is being called tools for thought And most of
+  the community is focused on building more software
 
-All of these are pre-computational
+  </div>
+  <div data-slide="33">
 
-</TalkSlide>
+  But it seems like these cultural practices are the real tools for thought
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-27.jpeg">
+  What we’re exploring with here is the relationship between the computer as a medium and the cultural
+  practices we do within the medium. And which one of those we should be focusing on…
 
-Hindu-arabic numerals made accounting and record keeping possible. Calculations could be stored,
-shared, and referenced Enabled all bureaucracy since.
+  </div>
+  <div data-slide="34">
 
-</TalkSlide>
+  So we’re still on this question. What does any of this have to do with computers?
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-28.jpeg">
+  To understand why we’re confused it’s worth going back to the origins of the phrase and the people
+  who proposed we should start paying attention to the idea.
 
-We’ve used poetry and song to extend memory and pass stories between generations before written
-language
+  </div>
+  <div data-slide="35">
 
-Bards used rhetorical techniques and metric rhythm to make the stories easy to recite.
+  TFT as a concept is rooted in computer science and HCI.
 
-It’s how pieces like the Epic of Gilgamesh and the Mahabrata survived long enough to eventually be
-written down
+  </div>
+  <div data-slide="36">
 
-</TalkSlide>
+  The first person to use the phrase was Kenneth Iverson talked about tools for thought throughout the
+  1950s-1960s wrote “Notation as a Tool for Thought, published by the ACM in 1980
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-29.jpeg">
+  </div>
+  <div data-slide="37">
 
-Maps enabled humans to mentally navigate space differently - gave us allocentric views vs.
-egocentric.
+  Talking about mathematical notation as the best known and best developed example of a tool for
+  thought.
 
-We're able to construct mental models of much larger spaces that we can't directly see
+  </div>
+  <div data-slide="38">
 
-</TalkSlide>
+  Around the same time period of the 1950’s and 60’s Douglas Englebart wrote “Augmenting the Human
+  Intellect”
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-30.jpeg">
+  </div>
+  <div data-slide="39">
 
-Cartesian coordinates; famously developed by Rene Descartes after watching a fly circle around his
-room
+  His thesis was computers should help us approach complex situations
 
-Made us able to describe points in space with specific numbers. Allows us to model objects that
-don’t exist with accuracy. Allows us to precisely map and refer to points on the earth. Led to GPS.
+  </div>
+  <div data-slide="40">
 
-</TalkSlide>
+  Alan Kay picked up a lot of this Philosophy and applied it while developing the foundations of most
+  of our current computing environments at Xerox PARC Wrote a paper called “User Interface: A Personal
+  View” in 1989 where he talked about his vision of the potential of computational mediums
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-31.jpeg">
+  </div>
+  <div data-slide="41">
 
-Zettelkasten (slip box) A technique from around the 18th century where you write atomic notes on
-individual index cards and keep them all in a large box or “slip box”. You assign each card an ID,
-and use those to link cards together to create deeply interconnected ideas.
+  Summed up in this quote
 
-Pre-cursor to deeply linked content we have with hyperlinking.
+  </div>
+  <div data-slide="42">
 
-</TalkSlide>
+  There’s a book called ‘tools for thought’ Howard Rheingold wrote a comprehensive summary of this
+  history in his 1985 book A lot about the birth of personal computers and many of the people I just
+  mentioned TFT went a bit quiet in the 90’s, not a lot written
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-32.jpeg">
+  </div>
+  <div data-slide="43">
 
-But this is primarily a list of cultural practices and systems; they are techniques – a way of doing
-things - that enable us to relate to information and representation in new ways. Thus enabling new
-kinds of thoughts.
+  Around 2013 Bret Victor starts doing talks For the newer generation his work becomes canon. The
+  Humane Representation of Thought, and Media for Thinking the Unthinkable between 2013-2015
 
-</TalkSlide>
+  All of these programmers are pushing this idea that we need to be building new tools for thought.
+  And most of the people listening to them or reading their work are computer people. And so we end up
+  assuming the problem is a computer-shaped problem.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-33.jpeg">
+  </div>
+  <div data-slide="44">
 
-They aren’t technological objects like hammers or compasses. They’re practices that people developed
-and passed down to one another through culture.
+  Another interesting thing about the way these programmers are talking about “tools for thought” is
+  that they're actually talking about a medium for thought, not a tool.
 
-Most of the things we’re all enamoured with in the current software moment around tools for thought
-are actually the practices we do inside the new tools, rather than the tools themselves
+  For philosophical clarity, these two are different
 
-</TalkSlide>
+  </div>
+  <div data-slide="45">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-34.jpeg">
+  Mediums are a material we use to communicate ideas: film, painting, writing, photography
 
-Most of the YouTube thought leaders turn out to be teaching specific practices – like building a
-Zettelkasten – rather than teaching us specific software.
+  </div>
+  <div data-slide="46">
 
-And it’s unclear how much enabling the software is doing vs. the cultural practice
+  Whereas tools enable specific workflows.
 
-</TalkSlide>
+  You don’t communicate through a hammer or agile. They’re part of a larger context – the medium.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-35.jpeg">
+  I think it’s important to be clear on the different between these two, but when we talk about “tools
+  for thought” as a category of things humans have used to expand their thinking, both are part of
+  that picture
 
-The same goes for spaced repetition - there are guides on how to do it in every platform imaginable.
+  </div>
+  <div data-slide="47">
 
-But we can’t quite tell if the app or the practice is what’s enabling people to improve their memory
+  I think its more accurate to say the thinkers I referenced so far are talking about a computational
+  medium for thought.
 
-</TalkSlide>
+  Where the computer-ness and medium-ness are critical elements
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-36.jpeg">
+  It should be CMFT, rather than TFT
 
-So we’re in an interesting place; all this software is being called tools for thought And most of
-the community is focused on building more software
+  </div>
+  <div data-slide="48">
 
-</TalkSlide>
+  Also clear than CMFT is a subset of TFT If TFT is all the tools and mediums that expand the range of
+  human thought, this community is specifically talking about the computer medium type
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-37.jpeg">
+  </div>
+  <div data-slide="49">
 
-But it seems like these cultural practices are the real tools for thought
+  So what’s so special about computers?
 
-What we’re exploring with here is the relationship between the computer as a medium and the cultural
-practices we do within the medium. And which one of those we should be focusing on…
+  </div>
+  <div data-slide="50">
 
-</TalkSlide>
+  I think this is best answered in this Alan Kay quote
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-38.jpeg">
+  </div>
+  <div data-slide="51">
 
-So we’re still on this question. What does any of this have to do with computers?
+  Encoding cultural practices in computation reconfigures, expands, and transforms them
 
-To understand why we’re confused it’s worth going back to the origins of the phrase and the people
-who proposed we should start paying attention to the idea.
+  The meta-medium changes the practice
 
-</TalkSlide>
+  We have to acknowledge there’s something very different about computing - in its ability to create
+  representations of the world that we can explore and manipulate, freed from many of the constraints
+  of physical materials.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-39.jpeg">
+  </div>
+  <div data-slide="52">
 
-TFT as a concept is rooted in computer science and HCI.
+  If we think about a Zettelkasten, which is a form of note-taking I mentioned earlier.
 
-</TalkSlide>
+  I think it would be slightly absurd to deny the fact a digital zettelkasten or note-taking system
+  has very different affordance to a physical zettelkasten. Even if they’re based on the same cultural
+  practices.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-40.jpeg">
+  The computational version changes what we’re able to do. Clearly expands our capacity in some way
 
-The first person to use the phrase was Kenneth Iverson talked about tools for thought throughout the
-1950s-1960s wrote “Notation as a Tool for Thought, published by the ACM in 1980
+  </div>
+  <div data-slide="53">
 
-</TalkSlide>
+  But even though computing expands some of the practices in new ways, we shouldn’t forget we're still
+  recreating cultural practices that first exist outside computing.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-41.jpeg">
+  Maps and spreadsheets and zettelkastens all existed before computers.
 
-Talking about mathematical notation as the best known and best developed example of a tool for
-thought.
+  Computing as an amplifier or enabler
 
-</TalkSlide>
+  </div>
+  <div data-slide="54">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-42.jpeg">
+  At the moment there is a LOT of staring, hard at the computer. Thinking about what the computer can
+  do. Thinking about software and interfaces and novel ways to store and retrieve data Which is
+  necessary… to some extent. But there’s not a lot of attention put on the cultural practices we're
+  trying to represent
 
-Around the same time period of the 1950’s and 60’s Douglas Englebart wrote “Augmenting the Human
-Intellect”
+  </div>
+  <div data-slide="55">
 
-</TalkSlide>
+  We’re currently enabling a fairly small range of activities.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-43.jpeg">
+  Primarily:
 
-His thesis was computers should help us approach complex situations
+  - capturing information (and much debate over which specific format to capture it in and where that
+    data lives)
+  - Organising information. This includes linking, tagging, categorising it.
+  - Retrieving information. This means search, and being able to find the right information at the
+    right time. Having relevant information appear when you need it
+  - Remembering information. These are the spaced repetition systems.
 
-</TalkSlide>
+  </div>
+  <div data-slide="56">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-44.jpeg">
+  - Searching for new information.
+  - Synthesising ideas.
+  - Generating ideas.
 
-Alan Kay picked up a lot of this Philosophy and applied it while developing the foundations of most
-of our current computing environments at Xerox PARC Wrote a paper called “User Interface: A Personal
-View” in 1989 where he talked about his vision of the potential of computational mediums
+  I’d argue we’re not very good at these last three at the moment, but that's primarily a lot of what
+  people are trying to get AI and language models to do. I’ll come back to AI in a bit.
 
-</TalkSlide>
+  </div>
+  <div data-slide="57">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-45.jpeg">
+  These actives all serve a particular flavour of knowledge work.
 
-Summed up in this quote
+  Work that is based around research and written output with a textual focus. Helping people write
+  documents and code and presentation slides.
 
-</TalkSlide>
+  Good for academics, social scientists, strategists, journalists, teachers, consultants, VC,
+  Twittering thought leaders, and (unsurprisingly) programmers.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-46.jpeg">
+  We’re mostly designing for ourselves.
 
-There’s a book called ‘tools for thought’ Howard Rheingold wrote a comprehensive summary of this
-history in his 1985 book A lot about the birth of personal computers and many of the people I just
-mentioned TFT went a bit quiet in the 90’s, not a lot written
+  </div>
+  <div data-slide="58">
 
-</TalkSlide>
+  At the moment, it feels like we’re not exploring computational mediums for thought, as much as we’re
+  exploring a subset of it I’m going to call… Computational mediums for White-collar knowledge work.
+  Of CMfWKW for convenience
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-47.jpeg">
+  Clear we need to expand our view of this field a little.
 
-Around 2013 Bret Victor starts doing talks For the newer generation his work becomes canon. The
-Humane Representation of Thought, and Media for Thinking the Unthinkable between 2013-2015
+  </div>
+  <div data-slide="59">
 
-All of these programmers are pushing this idea that we need to be building new tools for thought.
-And most of the people listening to them or reading their work are computer people. And so we end up
-assuming the problem is a computer-shaped problem.
+  The big question is how do we help the tools for thought community diversify?
 
-</TalkSlide>
+  How do we help move the community beyond computers for text-based white-collar knowledge work?
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-48.jpeg">
+  I have three overarching ideas of how we can start to do this.
 
-Another interesting thing about the way these programmers are talking about “tools for thought” is
-that they're actually talking about a medium for thought, not a tool.
+  </div>
+  <div data-slide="60">
 
-For philosophical clarity, these two are different
+  If we’re trying to look at what enables novel kinds of human thought, to me that’s an
+  anthropological and cognitive science question, not a computing question.
 
-</TalkSlide>
+  At the moment most people in this space are trying innovate without learning much about the world
+  outside of software, or the even outside the world of cool hyperlinks in web apps.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-49.jpeg">
+  I think the field would benefit from a much wider lens on the problem.
 
-Mediums are a material we use to communicate ideas: film, painting, writing, photography
+  Specifically, theories like embodied cognition, extended mind theory, and looking at examples of
+  cross-cultural ways of thinking from ethnographic research could add a lot to our conception of
+  tools for thought.
 
-</TalkSlide>
+  </div>
+  <div data-slide="61">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-50.jpeg">
+  To name just a few, we could look at the work of philosophers like Andy Clark, who's written
+  extensively about about how human cognition interacts with the environments around us.
 
-Whereas tools enable specific workflows.
+  This book “Natural Born Cyborgs” might look a bit dated, but all the content inside it is still
+  extremely prescient and relevant. It's not his only book on the subject, but I think it's one of the
+  more accessible ones.
 
-You don’t communicate through a hammer or agile. They’re part of a larger context – the medium.
+  In it, Clark presents the extended mind hypothesis that says we don't think inside of our brains,
+  but we think in the relationship between our brains, our bodies and the world around us.
 
-I think it’s important to be clear on the different between these two, but when we talk about “tools
-for thought” as a category of things humans have used to expand their thinking, both are part of
-that picture
+  </div>
+  <div data-slide="62">
 
-</TalkSlide>
+  George Lakoff’s research on embodied metaphors as the foundation of all conceptual thought
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-51.jpeg">
+  This book is short, it's pretty readable, and it will make you rethink the way you understand how
+  abstract thought is constructed.
 
-I think its more accurate to say the thinkers I referenced so far are talking about a computational
-medium for thought.
+  Lakoff and Johnson argue that everything is grounded in our embodied experience of the world, which
+  certainly has implications for AI, but again I will not get into that now.
 
-Where the computer-ness and medium-ness are critical elements
+  </div>
+  <div data-slide="63">
 
-It should be CMFT, rather than TFT
+  Similarly, Barbara Tversky has done an extensive amount of research on how thinking happens through
+  the body and through action and motion in the body.
 
-</TalkSlide>
+  Both this book and almost any of the existing research on embodied cognition will convince you that
+  the way humans think is deeply tied to our physical interactions with the world around us, and our
+  understanding space, colour, light, sound, texture, and rich visual inputs.I imagine none of this is
+  news to your research group. You know bodies are important. But not everyone does.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-52.jpeg">
+  </div>
+  <div data-slide="64">
 
-Also clear than CMFT is a subset of TFT If TFT is all the tools and mediums that expand the range of
-human thought, this community is specifically talking about the computer medium type
+  Some notable others include anthropologist Tim Ingold who's done an enormous amount of work on how
+  humans build techniques and skills in relationship with the environment they live within.
 
-</TalkSlide>
+  There's also Bruno Latour, another anthropologist who worked on actor network theory. Maurice
+  Merleau-Ponty, very famous for setting the foundations of embodied cognition. Marshall McLuhan for
+  talking about the relationship between mediums and communication. And I'm sure you all know, Don
+  Norman came up with the idea of cognitive artefacts.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-53.jpeg">
+  This is not a comprehensive list, but a good starting point. I think one of the most useful things
+  we could as the Tools for Thought community is to spread around the knowledge that these thinkers
+  have established and use it more as the foundation of our work.
 
-So what’s so special about computers?
+  </div>
+  <div data-slide="65">
 
-</TalkSlide>
+  And the reason I think we're not doing that at the moment is because I look around and have to ask,
+  where are all the embodied visual, spatial, and aural tools for thought?
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-54.jpeg">
+  Professions that primarily work in non-textual mediums are unlikely to find the “tools for thought”
+  we’re currently offering as profoundly helpful.
 
-I think this is best answered in this Alan Kay quote
+  We of course of have software that serves some of these disciplines very well; spreadsheets for
+  mathematics, 3D modelling for biologists, data science, photoshop for painters, logic pro for
+  musicians. But strangely these don’t show up a lot in the tools for thought community.
 
-</TalkSlide>
+  </div>
+  <div data-slide="66">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-55.jpeg">
+  To give you some examples of what I mean, I would consider AlphaFold from DeepMind, a good example
+  of non-textual, spatial tool for thought.
 
-Encoding cultural practices in computation reconfigures, expands, and transforms them
+  </div>
+  <div data-slide="67">
 
-The meta-medium changes the practice
+  Jacob Collier. Grammy-winning musician showing an extraordinarily complex breakdown of his song Moon
+  River in logic pro.
 
-We have to acknowledge there’s something very different about computing - in its ability to create
-representations of the world that we can explore and manipulate, freed from many of the constraints
-of physical materials.
+  Over an hour, but an exceptional example a computation medium enabling wildly different kinds of
+  musical thought.
 
-</TalkSlide>
+  </div>
+  <div data-slide="68">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-56.jpeg">
+  New image generators for visual brainstorming and exploring visual culture
 
-If we think about a Zettelkasten, which is a form of note-taking I mentioned earlier.
+  These are images from Midjourney. Image generators are controversial for other reasons like copyright, but
+  as a creative thinking tool, I think they’re worth exploring.
 
-I think it would be slightly absurd to deny the fact a digital zettelkasten or note-taking system
-has very different affordance to a physical zettelkasten. Even if they’re based on the same cultural
-practices.
+  We still have to figure out how to get more fine grained control over the outputs. But its very
+  promising.
 
-The computational version changes what we’re able to do. Clearly expands our capacity in some way
+  </div>
+  <div data-slide="69">
 
-</TalkSlide>
+  VR obviously exploring embodied cognition side of things
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-57.jpeg">
+  Prisms VR for spatial reasoning with maths
 
-But even though computing expands some of the practices in new ways, we shouldn’t forget we're still
-recreating cultural practices that first exist outside computing.
+  </div>
+  <div data-slide="70">
 
-Maps and spreadsheets and zettelkastens all existed before computers.
+  Prisms VR for spatial reasoning with maths
 
-Computing as an amplifier or enabler
+  </div>
+  <div data-slide="71">
 
-</TalkSlide>
+  On that note… It’s funny to be in the current moment of the AI hype bubble, where the professed goal
+  of burning all these GPUs is to invent thinking machines.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-58.jpeg">
+  People hope to make these machines reason and problem solve better than humans can and solve all our
+  complex problems.
 
-At the moment there is a LOT of staring, hard at the computer. Thinking about what the computer can
-do. Thinking about software and interfaces and novel ways to store and retrieve data Which is
-necessary… to some extent. But there’s not a lot of attention put on the cultural practices we're
-trying to represent
+  And yet we've gone about it by an intensely disembodied and textual technique, by literally only
+  dumping text into these models, so that all they know is text.
 
-</TalkSlide>
+  Language models – the primary kind of AI most people are putting the most stock in – lack an
+  understand of bodies, objects, and environments interacting in space and over time. Which the
+  literature shows is core to the way humans think.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-59.jpeg">
+  That doesn’t mean they won’t produce useful tools for us, but they will not recreate anything
+  resembling human thinking and problem solving. At least not without giving them some way to
+  understand embodiment and motion and interaction with the physical world.
 
-We’re currently enabling a fairly small range of activities.
+  So just consider that next time someone tells you that GPT-5 is going to solve climate change.
 
-Primarily:
+  </div>
+  <div data-slide="72">
 
-- capturing information (and much debate over which specific format to capture it in and where that
-  data lives)
-- Organising information. This includes linking, tagging, categorising it.
-- Retrieving information. This means search, and being able to find the right information at the
-  right time. Having relevant information appear when you need it
-- Remembering information. These are the spaced repetition systems.
+  The second way to diversify tools for thought is to build complementary, not competitive artefacts
 
-</TalkSlide>
+  </div>
+  <div data-slide="73">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-60.jpeg">
+  This theory comes from David Krakauer of the Santa Fe Institute.
 
-- Searching for new information.
-- Synthesising ideas.
-- Generating ideas.
+  Competitive artefacts do the cognitive work for you and hide their workings. So when you take the
+  tool away, you've actually diminished your skills because you haven't been practicing it. They
+  compete with us in a way.
 
-I’d argue we’re not very good at these last three at the moment, but that's primarily a lot of what
-people are trying to get AI and language models to do. I’ll come back to AI in a bit.
+  While complementary artefacts teach you new cognitive skills through using the tool. They complement
+  your abilities and they make you more capable even when you don't have the tool with you.
 
-</TalkSlide>
+  </div>
+  <div data-slide="74">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-61.jpeg">
+  A good example of this is Google Maps versus a compass
 
-These actives all serve a particular flavour of knowledge work.
+  Using Google Maps doesn't make you better at navigating the world around you. It tells you exactly
+  where to go without relating it to local landmarks or the position of the sun or helping you develop
+  a sense of direction in the world. If you take Google Maps away, none of us are better at navigating
+  our cities.
 
-Work that is based around research and written output with a textual focus. Helping people write
-documents and code and presentation slides.
+  Whereas a compass makes you look up more, makes you pay attention to the physical world around you,
+  and teaches you how to relate the direction you're in to the physical world you're seeing via
+  landmarks like the sun. It teaches you navigation skills that would remain if we took the compass
+  away.
 
-Good for academics, social scientists, strategists, journalists, teachers, consultants, VC,
-Twittering thought leaders, and (unsurprisingly) programmers.
+  </div>
+  <div data-slide="75">
 
-We’re mostly designing for ourselves.
+  One prescient example at the moment is coding assistants like Copilot.
 
-</TalkSlide>
+  I think used in some ways these could be complementary, but the vast majority of uses I've seen of
+  them are actually competitive. They're not helping you learn how to solve programming problems
+  yourself, especially if you're not reading the code that they output.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-62.jpeg">
+  It would be interesting to try to redesign copilot and focus a making it a complementary tool that
+  slowly teaches you programmatic thinking versus doing things like applying large code chunks to
+  files or rewriting entire files for you.
 
-At the moment, it feels like we’re not exploring computational mediums for thought, as much as we’re
-exploring a subset of it I’m going to call… Computational mediums for White-collar knowledge work.
-Of CMfWKW for convenience
+  </div>
+  <div data-slide="76">
 
-Clear we need to expand our view of this field a little.
+  Third thing I think is missing is the whole mission of this talk
 
-</TalkSlide>
+  I think we need to pay much more attention to cultural practices, not computational objects.
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-63.jpeg">
+  There are tons of pre-existing, super effective cultural practices that make us better at thinking.
+  And we should be considering how we could enable more people to use them. Perhaps with computers,
+  but perhaps not.
 
-The big question is how do we help the tools for thought community diversify?
+  </div>
+  <div data-slide="77">
 
-How do we help move the community beyond computers for text-based white-collar knowledge work?
+  Just to give you a few examples of some under explored ones:
 
-I have three overarching ideas of how we can start to do this.
+  - Spatial memory. We have extremely effective memories when we relate facts to physical space. I
+    haven't seen that much exploration of designing tools to help people build memory palaces.
+  - Classical rhetoric. This is how the ancient Greeks and Romans developed convincing arguments. We
+    could build tools that teach us how to use ethos, pathos, and logos. And bring in more
+    alliteration and antithesis and analogies.
+  - Critical thinking skills. This is a huge category. What tools do we have that help us question and
+    interrogate claims we come across? And get us to question our assumptions and prove ourselves
+    wrong? And point out our unconscious biases and logical fallacies?
+  - Statistics and statistical manipulation. We all famously know statistics are mostly lies. But
+    being able to understand and interpret statistics is an incredibly powerful tool to understand big
+    data. And I think most of us, me included, are pretty illiterate in statistics. I would love tools
+    that help me correctly interpret and put into context data that I encounter on a daily basis.
+  - Information literacy skills. Obviously shown to be pretty low across the population. And getting
+    worse as AI Slop fills every single online platform. Do any of your current tools help thoroughly
+    vet the sources and legitimacy of information you encounter throughout the day? Do they help you
+    compare and contrast arguments you read and come to more informed and synthesised conclusions? No!
+    Or at least mine don’t. If yours do, I want to know what apps you’re using.
 
-</TalkSlide>
+  </div>
+  <div data-slide="78">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-64.jpeg">
+  There's lots of places to look for more practices like these. Daniel Bennett has a bunch of good
+  examples of these in his book “Intuition Pumps and Other Tools for Thinking”. He wasn’t explicitly
+  referencing any of the pre-existing computational literature on TFT when he wrote this.
 
-If we’re trying to look at what enables novel kinds of human thought, to me that’s an
-anthropological and cognitive science question, not a computing question.
+  The way he thinks about TFT is similar to what I proposed at the beginning; cites words, numbers,
+  maps, diagrams. But, being he philosopher, he is especially interested in “intuition pumps” which is
+  his own term meaning reasoning moves that help you think critically about philosophical problems.
+  These include following Rapport’s rules, Joosting, and Rathering. If you want to know what those
+  are, you’ll have to read the book.
 
-At the moment most people in this space are trying innovate without learning much about the world
-outside of software, or the even outside the world of cool hyperlinks in web apps.
+  </div>
+  <div data-slide="79">
 
-I think the field would benefit from a much wider lens on the problem.
+  In other words, we should be building tools that give people new lenses on the world. That teach you
+  how to see and think in useful new ways.
 
-Specifically, theories like embodied cognition, extended mind theory, and looking at examples of
-cross-cultural ways of thinking from ethnographic research could add a lot to our conception of
-tools for thought.
+  I know a lot of the examples I showed probably fall under the category of critical thinking lenses.
+  But you could also teach people to see through an emotional lens, or see the world through the lens
+  of complexity theory and emergence. To me, these are the most promising “tools for thought.”
 
-</TalkSlide>
+  </div>
+  <div data-slide="80">
 
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-65.jpeg">
+  Thanks very much for listening.
 
-To name just a few, we could look at the work of philosophers like Andy Clark, who's written
-extensively about about how human cognition interacts with the environments around us.
-
-This book “Natural Born Cyborgs” might look a bit dated, but all the content inside it is still
-extremely prescient and relevant. It's not his only book on the subject, but I think it's one of the
-more accessible ones.
-
-In it, Clark presents the extended mind hypothesis that says we don't think inside of our brains,
-but we think in the relationship between our brains, our bodies and the world around us.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-66.jpeg">
-
-George Lakoff’s research on embodied metaphors as the foundation of all conceptual thought
-
-This book is short, it's pretty readable, and it will make you rethink the way you understand how
-abstract thought is constructed.
-
-Lakoff and Johnson argue that everything is grounded in our embodied experience of the world, which
-certainly has implications for AI, but again I will not get into that now.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-67.jpeg">
-
-Similarly, Barbara Tversky has done an extensive amount of research on how thinking happens through
-the body and through action and motion in the body.
-
-Both this book and almost any of the existing research on embodied cognition will convince you that
-the way humans think is deeply tied to our physical interactions with the world around us, and our
-understanding space, colour, light, sound, texture, and rich visual inputs.I imagine none of this is
-news to your research group. You know bodies are important. But not everyone does.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-68.jpeg">
-
-Some notable others include anthropologist Tim Ingold who's done an enormous amount of work on how
-humans build techniques and skills in relationship with the environment they live within.
-
-There's also Bruno Latour, another anthropologist who worked on actor network theory. Maurice
-Merleau-Ponty, very famous for setting the foundations of embodied cognition. Marshall McLuhan for
-talking about the relationship between mediums and communication. And I'm sure you all know, Don
-Norman came up with the idea of cognitive artefacts.
-
-This is not a comprehensive list, but a good starting point. I think one of the most useful things
-we could as the Tools for Thought community is to spread around the knowledge that these thinkers
-have established and use it more as the foundation of our work.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-69.jpeg">
-
-And the reason I think we're not doing that at the moment is because I look around and have to ask,
-where are all the embodied visual, spatial, and aural tools for thought?
-
-Professions that primarily work in non-textual mediums are unlikely to find the “tools for thought”
-we’re currently offering as profoundly helpful.
-
-We of course of have software that serves some of these disciplines very well; spreadsheets for
-mathematics, 3D modelling for biologists, data science, photoshop for painters, logic pro for
-musicians. But strangely these don’t show up a lot in the tools for thought community.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-70.jpeg">
-
-To give you some examples of what I mean, I would consider AlphaFold from DeepMind, a good example
-of non-textual, spatial tool for thought.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-71.jpeg">
-
-Jacob Collier. Grammy-winning musician showing an extraordinarily complex breakdown of his song Moon
-River in logic pro.
-
-Over an hour, but an exceptional example a computation medium enabling wildly different kinds of
-musical thought.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-72.jpeg">
-
-New image generators for visual brainstorming and exploring visual culture
-
-These are images from Midjourney. Image generators are controversial for other reasons like copyright, but
-as a creative thinking tool, I think they’re worth exploring.
-
-We still have to figure out how to get more fine grained control over the outputs. But its very
-promising.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-73.jpeg">
-
-VR obviously exploring embodied cognition side of things
-
-Prisms VR for spatial reasoning with maths
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-74.jpeg">
-
-Prisms VR for spatial reasoning with maths
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-75.jpeg">
-
-On that note… It’s funny to be in the current moment of the AI hype bubble, where the professed goal
-of burning all these GPUs is to invent thinking machines.
-
-People hope to make these machines reason and problem solve better than humans can and solve all our
-complex problems.
-
-And yet we've gone about it by an intensely disembodied and textual technique, by literally only
-dumping text into these models, so that all they know is text.
-
-Language models – the primary kind of AI most people are putting the most stock in – lack an
-understand of bodies, objects, and environments interacting in space and over time. Which the
-literature shows is core to the way humans think.
-
-That doesn’t mean they won’t produce useful tools for us, but they will not recreate anything
-resembling human thinking and problem solving. At least not without giving them some way to
-understand embodiment and motion and interaction with the physical world.
-
-So just consider that next time someone tells you that GPT-5 is going to solve climate change.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-76.jpeg">
-
-The second way to diversify tools for thought is to build complementary, not competitive artefacts
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-77.jpeg">
-
-This theory comes from David Krakauer of the Santa Fe Institute.
-
-Competitive artefacts do the cognitive work for you and hide their workings. So when you take the
-tool away, you've actually diminished your skills because you haven't been practicing it. They
-compete with us in a way.
-
-While complementary artefacts teach you new cognitive skills through using the tool. They complement
-your abilities and they make you more capable even when you don't have the tool with you.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-78.jpeg">
-
-A good example of this is Google Maps versus a compass
-
-Using Google Maps doesn't make you better at navigating the world around you. It tells you exactly
-where to go without relating it to local landmarks or the position of the sun or helping you develop
-a sense of direction in the world. If you take Google Maps away, none of us are better at navigating
-our cities.
-
-Whereas a compass makes you look up more, makes you pay attention to the physical world around you,
-and teaches you how to relate the direction you're in to the physical world you're seeing via
-landmarks like the sun. It teaches you navigation skills that would remain if we took the compass
-away.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-79.jpeg">
-
-One prescient example at the moment is coding assistants like Copilot.
-
-I think used in some ways these could be complementary, but the vast majority of uses I've seen of
-them are actually competitive. They're not helping you learn how to solve programming problems
-yourself, especially if you're not reading the code that they output.
-
-It would be interesting to try to redesign copilot and focus a making it a complementary tool that
-slowly teaches you programmatic thinking versus doing things like applying large code chunks to
-files or rewriting entire files for you.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-80.jpeg">
-
-Third thing I think is missing is the whole mission of this talk
-
-I think we need to pay much more attention to cultural practices, not computational objects.
-
-There are tons of pre-existing, super effective cultural practices that make us better at thinking.
-And we should be considering how we could enable more people to use them. Perhaps with computers,
-but perhaps not.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-81.jpeg">
-
-Just to give you a few examples of some under explored ones:
-
-- Spatial memory. We have extremely effective memories when we relate facts to physical space. I
-  haven't seen that much exploration of designing tools to help people build memory palaces.
-- Classical rhetoric. This is how the ancient Greeks and Romans developed convincing arguments. We
-  could build tools that teach us how to use ethos, pathos, and logos. And bring in more
-  alliteration and antithesis and analogies.
-- Critical thinking skills. This is a huge category. What tools do we have that help us question and
-  interrogate claims we come across? And get us to question our assumptions and prove ourselves
-  wrong? And point out our unconscious biases and logical fallacies?
-- Statistics and statistical manipulation. We all famously know statistics are mostly lies. But
-  being able to understand and interpret statistics is an incredibly powerful tool to understand big
-  data. And I think most of us, me included, are pretty illiterate in statistics. I would love tools
-  that help me correctly interpret and put into context data that I encounter on a daily basis.
-- Information literacy skills. Obviously shown to be pretty low across the population. And getting
-  worse as AI Slop fills every single online platform. Do any of your current tools help thoroughly
-  vet the sources and legitimacy of information you encounter throughout the day? Do they help you
-  compare and contrast arguments you read and come to more informed and synthesised conclusions? No!
-  Or at least mine don’t. If yours do, I want to know what apps you’re using.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-82.jpeg">
-
-There's lots of places to look for more practices like these. Daniel Bennett has a bunch of good
-examples of these in his book “Intuition Pumps and Other Tools for Thinking”. He wasn’t explicitly
-referencing any of the pre-existing computational literature on TFT when he wrote this.
-
-The way he thinks about TFT is similar to what I proposed at the beginning; cites words, numbers,
-maps, diagrams. But, being he philosopher, he is especially interested in “intuition pumps” which is
-his own term meaning reasoning moves that help you think critically about philosophical problems.
-These include following Rapport’s rules, Joosting, and Rathering. If you want to know what those
-are, you’ll have to read the book.
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-83.jpeg">
-
-In other words, we should be building tools that give people new lenses on the world. That teach you
-how to see and think in useful new ways.
-
-I know a lot of the examples I showed probably fall under the category of critical thinking lenses.
-But you could also teach people to see through an emotional lens, or see the world through the lens
-of complexity theory and emergence. To me, these are the most promising “tools for thought.”
-
-</TalkSlide>
-
-<TalkSlide imgSrc="/images/posts/tft-talk/TFT-V6-84.jpeg">
-
-Thanks very much for listening.
-
-</TalkSlide>
+  </div>
+</ScrollyTalkSection>


### PR DESCRIPTION
## Summary

- Converts forest-talk (121 slides), home-cooked-software (89 slides), squish-structure (73 slides), and tools-thought-talk (81 slides) from the `TalkSlide` component to the new `ScrollyTalkSection` scrollytelling layout
- Used a Python script for programmatic transformation with automated verification (image count, text preservation, sequential numbering) to ensure zero data loss across all 364 slides
- Each file's import updated from `TalkSlide` to `ScrollyTalkSection`, images consolidated into a single array prop, and text content wrapped in `<div data-slide="N">` elements

## Test plan
- [x] Python script verified all image paths preserved in output
- [x] Python script verified all text content preserved in output
- [x] Python script verified sequential slide numbering (0 to N-1)
- [x] `astro build` passed after each individual file conversion
- [ ] Visual spot-check of each talk page in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)