### PR TITLE
Fix Garmin data viz not rendering on /growing-a-human

### DIFF
--- a/src/components/unique/GarminData.astro
+++ b/src/components/unique/GarminData.astro
@@ -889,7 +889,7 @@ const data = [
 	let resizeHandler: (() => void) | null = null;
 
 	onPageLifecycle(() => {
-		const container = document.querySelector(".garmin-chart-container");
+		const container = document.querySelector(".chart-container");
 		if (container) initChart();
 
 		return () => {


### PR DESCRIPTION
## Summary
- The view transitions lifecycle refactor (#28, commit 7fada52) introduced a wrong CSS selector in `GarminData.astro`: `.garmin-chart-container` instead of the actual `.chart-container`
- This caused the `onPageLifecycle` guard to silently skip `initChart()`, so the D3 chart never rendered
- Fix: correct the selector to match the existing HTML template

## Test plan
- [ ] Run dev server and navigate to `/growing-a-human`
- [ ] Confirm the Garmin D3 chart renders with three line graphs (HR, sleep, stress)
- [ ] Hover over chart to verify tooltips work
- [ ] Navigate away and back via view transitions — chart should re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)