### PR TITLE
Fix inline emojis and font on /drawinginvisibles1

### DIFF
--- a/src/components/mdx/GridColumns.astro
+++ b/src/components/mdx/GridColumns.astro
@@ -43,6 +43,7 @@ const finalMaxWidth = maxWidth || width || "1400px";
 		padding: 0 var(--space-3xs);
 		overflow-x: hidden;
 		justify-content: center;
+		font-family: var(--font-body);
 	}
 
 	.grid-container :global(p) {

--- a/src/content/essays/drawinginvisibles1.mdx
+++ b/src/content/essays/drawinginvisibles1.mdx
@@ -377,36 +377,7 @@ I'm going to use the <span role="img" aria-label="target"> 🎯 </span> emoji to
 
 <span style={{ maxWidth: "550px", paddingLeft: "1em" }}>
 	<h4 style={{ marginTop: 0 }}>Advanced CSS Selectors</h4>
-	The webpage
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	is a customisable house
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Individual elements on the webpage{" "}
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>{" "}
-	are different parts of the house{" "}
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Selecting web elements with specific CSS styles{" "}
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>{" "}
-	is selectively painting parts of the house various colors{" "}
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
+	The webpage <span role="img" aria-label="target">🎯</span> is a customisable house <span role="img" aria-label="source">⛲️</span>. Individual elements on the webpage <span role="img" aria-label="target">🎯</span> are different parts of the house <span role="img" aria-label="source">⛲️</span>. Selecting web elements with specific CSS styles <span role="img" aria-label="target">🎯</span> is selectively painting parts of the house various colors <span role="img" aria-label="source">⛲️</span>
 	<Footnote idName={7}>
 		Yes, this whole metaphor is taking place inside a game of The Sims
 	</Footnote>
@@ -419,39 +390,7 @@ I'm going to use the <span role="img" aria-label="target"> 🎯 </span> emoji to
 
 <span style={{ maxWidth: "550px", paddingLeft: "1em" }}>
 	<h4 style={{ marginTop: 0 }}>Reduce Redux Boilerplate with Redux-Actions</h4>
-	Redux
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	is the <YearsAgo>1978</YearsAgo> arcade game [Space
-	Invaders](https://en.wikipedia.org/wiki/Space_Invaders)
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. The Redux-Actions library{" "}
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>{" "}
-	is a combination of the joystick, and the two tiny spaceships it controls
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Boilerplate redux code that we want to get rid of
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>{" "}
-	is an army of space invader aliens, being zapped into oblivion by the
-	Redux-Action spaceships{" "}
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	.
+	Redux <span role="img" aria-label="target">🎯</span> is the <YearsAgo>1978</YearsAgo> arcade game [Space Invaders](https://en.wikipedia.org/wiki/Space_Invaders) <span role="img" aria-label="source">⛲️</span>. The Redux-Actions library <span role="img" aria-label="target">🎯</span> is a combination of the joystick, and the two tiny spaceships it controls <span role="img" aria-label="source">⛲️</span>. Boilerplate redux code that we want to get rid of <span role="img" aria-label="target">🎯</span> is an army of space invader aliens, being zapped into oblivion by the Redux-Action spaceships <span role="img" aria-label="source">⛲️</span>.
 </span>
 
 <RemoteImage
@@ -461,47 +400,7 @@ I'm going to use the <span role="img" aria-label="target"> 🎯 </span> emoji to
 
 <span style={{ maxWidth: "550px", paddingLeft: "1em" }}>
 	<h4 style={{ marginTop: 0 }}>Journey with Vue-Router</h4>
-	Vue-Router
-	<span role="img" aria-label="target">
-		{" "}
-		🎯
-	</span>
-	is an underground railway system with train carriages travelling along it
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Each page in a Vue application
-	<span role="img" aria-label="target">
-		{" "}
-		🎯
-	</span>{" "}
-	is a station{" "}
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>{" "}
-	. The user clicking between pages{" "}
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>{" "}
-	is riding the train between stations{" "}
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Building new routes between pages{" "}
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>{" "}
-	is laying down new train tracks and between stations{" "}
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	.
+	Vue-Router <span role="img" aria-label="target">🎯</span> is an underground railway system with train carriages travelling along it <span role="img" aria-label="source">⛲️</span>. Each page in a Vue application <span role="img" aria-label="target">🎯</span> is a station <span role="img" aria-label="source">⛲️</span>. The user clicking between pages <span role="img" aria-label="target">🎯</span> is riding the train between stations <span role="img" aria-label="source">⛲️</span>. Building new routes between pages <span role="img" aria-label="target">🎯</span> is laying down new train tracks and between stations <span role="img" aria-label="source">⛲️</span>.
 </span>
 
 </GridColumns>
@@ -518,27 +417,7 @@ Two illustrators I consider the cream of the metaphorical crop are <a href="http
 	sourceTitle="Political Hobbyism"
 	illustrator="Matt Chase"
 >
-	Polticial action
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	is a speaking through a megaphone
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Hobbyism and passivity
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	is lounging around on the couch
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	.
+	Polticial action <span role="img" aria-label="target">🎯</span> is a speaking through a megaphone <span role="img" aria-label="source">⛲️</span>. Hobbyism and passivity <span role="img" aria-label="target">🎯</span> is lounging around on the couch <span role="img" aria-label="source">⛲️</span>.
 </InvisiblesFeature>
 
 <InvisiblesFeature
@@ -547,37 +426,7 @@ Two illustrators I consider the cream of the metaphorical crop are <a href="http
 	sourceTitle="Snake Oil Job Training for Midlife Career Changers"
 	illustrator="Emiliano Ponzi"
 >
-	A career
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	is a journey along a road
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Facing trouble on a a career journey
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	is a the road turning into a wall
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Snake oil training services
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	are a road running upsidedown and backwards
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	.
+	A career <span role="img" aria-label="target">🎯</span> is a journey along a road <span role="img" aria-label="source">⛲️</span>. Facing trouble on a a career journey <span role="img" aria-label="target">🎯</span> is a the road turning into a wall <span role="img" aria-label="source">⛲️</span>. Snake oil training services <span role="img" aria-label="target">🎯</span> are a road running upsidedown and backwards <span role="img" aria-label="source">⛲️</span>.
 </InvisiblesFeature>
 
 <InvisiblesFeature
@@ -586,27 +435,7 @@ Two illustrators I consider the cream of the metaphorical crop are <a href="http
 	sourceTitle="Prolonged Prosecutions in Guatemalan Courts"
 	illustrator="Matt Chase"
 >
-	The justice system
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	is a set of balance scales
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Prolonged and corrupt court cases
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	are a tangled mess
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	.
+	The justice system <span role="img" aria-label="target">🎯</span> is a set of balance scales <span role="img" aria-label="source">⛲️</span>. Prolonged and corrupt court cases <span role="img" aria-label="target">🎯</span> are a tangled mess <span role="img" aria-label="source">⛲️</span>.
 </InvisiblesFeature>
 
 <InvisiblesFeature
@@ -615,37 +444,7 @@ Two illustrators I consider the cream of the metaphorical crop are <a href="http
 	sourceTitle="The Art of Improvisation"
 	illustrator="Emiliano Ponzi"
 >
-	A challenge
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	is a maze
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Following the traditional rules
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	is getting to the centre of a maze by walking between the hedges
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	. Improvisation
-	<span role="img" aria-label="target">
-		{" "}
-		🎯{" "}
-	</span>
-	is getting to the center by mowing a path through the hedges
-	<span role="img" aria-label="source">
-		{" "}
-		⛲️{" "}
-	</span>
-	.
+	A challenge <span role="img" aria-label="target">🎯</span> is a maze <span role="img" aria-label="source">⛲️</span>. Following the traditional rules <span role="img" aria-label="target">🎯</span> is getting to the centre of a maze by walking between the hedges <span role="img" aria-label="source">⛲️</span>. Improvisation <span role="img" aria-label="target">🎯</span> is getting to the center by mowing a path through the hedges <span role="img" aria-label="source">⛲️</span>.
 </InvisiblesFeature>
 
 <hr />


### PR DESCRIPTION
## Summary
- Collapsed multi-line emoji `<span>` elements onto single lines so 🎯 and ⛲️ render inline with text instead of on separate lines
- Added `font-family: var(--font-body)` to `GridColumns` component so text inside grids inherits the correct "Canela Text" typeface
- Fixes affect all 7 emoji sections in the drawinginvisibles1 essay (3 in GridColumns, 4 in InvisiblesFeature)

## Test plan
- [ ] Verify emojis render inline with surrounding text on `/drawinginvisibles1`
- [ ] Verify the correct serif typeface (Canela Text) is applied to text in the GridColumns section
- [ ] Check other pages using GridColumns for any unintended font changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)