### PR TITLE
Fix dot separator vertical alignment on card metadata

### DIFF
--- a/src/components/cards/NoteCard.astro
+++ b/src/components/cards/NoteCard.astro
@@ -12,7 +12,7 @@ import GrowthIcon from "../layouts/GrowthIcon.astro";
 			<p class="description">{description}</p>
 			<div class="metadata-container">
 				<span>Note</span>
-				<svg width="4px" height="10px">
+				<svg width="4px" height="4px">
 					<circle r="2" cx="2" cy="2" fill="var(--color-gray-400)"></circle>
 				</svg>
 				<RelativeDate postDate={date} />
@@ -36,8 +36,10 @@ import GrowthIcon from "../layouts/GrowthIcon.astro";
 		font-weight: 400;
 	}
 
-	.metadata-container svg {
+	.note-card .metadata-container svg {
 		margin: 0 0.4rem;
+		position: relative;
+		top: 1px;
 	}
 
 	.description {

--- a/src/components/cards/NowCard.astro
+++ b/src/components/cards/NowCard.astro
@@ -36,7 +36,7 @@ import { Icon } from "astro-icon/components";
 		font-weight: 400;
 	}
 
-	.metadata-container svg {
+	.now-card .metadata-container svg {
 		margin: 0 0.4rem;
 		position: relative;
 		top: 1px;

--- a/src/components/cards/NowCard.astro
+++ b/src/components/cards/NowCard.astro
@@ -12,7 +12,7 @@ import { Icon } from "astro-icon/components";
 			{preview && <p class="description">{preview}...</p>}
 			<div class="metadata-container">
 				<span>Now Update</span>
-				<svg width="4px" height="10px">
+				<svg width="4px" height="4px">
 					<circle r="2" cx="2" cy="2" fill="var(--color-gray-400)"></circle>
 				</svg>
 				<RelativeDate postDate={date} />
@@ -38,6 +38,8 @@ import { Icon } from "astro-icon/components";
 
 	.metadata-container svg {
 		margin: 0 0.4rem;
+		position: relative;
+		top: 1px;
 	}
 
 	.description {

--- a/src/components/cards/PatternCard.astro
+++ b/src/components/cards/PatternCard.astro
@@ -12,7 +12,7 @@ import PatternIcon from "../icons/PatternIcon.astro";
 			<p class="description">{description}</p>
 			<div class="metadata-container">
 				<span>Pattern</span>
-				<svg width="4px" height="10px">
+				<svg width="4px" height="4px">
 					<circle r="2" cx="2" cy="2" fill="var(--color-gray-400)"></circle>
 				</svg>
 				<RelativeDate postDate={date} />
@@ -38,6 +38,8 @@ import PatternIcon from "../icons/PatternIcon.astro";
 
 	.metadata-container svg {
 		margin: 0 0.4rem;
+		position: relative;
+		top: 1px;
 	}
 
 	.description {

--- a/src/components/cards/TalkCard.astro
+++ b/src/components/cards/TalkCard.astro
@@ -37,7 +37,7 @@ import RelativeDate from "../layouts/RelativeDate.astro";
 			}
 			<div class="metadata-container">
 				<span>Talk</span>
-				<svg width="4px" height="10px">
+				<svg width="4px" height="4px">
 					<circle r="2" cx="2" cy="2" fill="var(--color-gray-400)"></circle>
 				</svg>
 				<RelativeDate postDate={date} />
@@ -123,6 +123,8 @@ import RelativeDate from "../layouts/RelativeDate.astro";
 
 	.metadata-container svg {
 		margin: 0 0.4rem;
+		position: relative;
+		top: 1px;
 	}
 
 	h3 {

--- a/src/links.json
+++ b/src/links.json
@@ -708,40 +708,6 @@
   },
   {
     "ids": [
-      "Frequently Asked Questions",
-      "frequently ask",
-      "FAQ"
-    ],
-    "slug": "faq",
-    "growthStage": "seedling",
-    "description": "Questions I am often asked to answer",
-    "outboundLinks": [
-      {
-        "matchedId": "What App is That?",
-        "title": "What App is That?",
-        "slug": "apps",
-        "growthStage": "evergreen",
-        "description": "A guide to the apps and tools I use to create illustrations"
-      },
-      {
-        "matchedId": "Drawing Invisible Programming Concepts",
-        "title": "How to Draw Invisible Programming Concepts: Part I",
-        "slug": "drawinginvisibles1",
-        "growthStage": "evergreen",
-        "description": "A case study showing how I make illustrations for abstract programming concepts"
-      }
-    ],
-    "inboundLinks": [
-      {
-        "title": "The Best Illustration Books and Courses",
-        "slug": "illustration-resources",
-        "growthStage": "evergreen",
-        "description": "My favourite resources for learning to draw and developing your visual thinking skills"
-      }
-    ]
-  },
-  {
-    "ids": [
       "JavaScript Bits You Skipped the First Time Around",
       "JavaScript prototype inheritance"
     ],
@@ -1538,6 +1504,40 @@
         "slug": "programmatic-notes",
         "growthStage": "evergreen",
         "description": "Agent-based note-taking systems that can prompt and facilitate custom workflows"
+      }
+    ]
+  },
+  {
+    "ids": [
+      "Frequently Asked Questions",
+      "frequently ask",
+      "FAQ"
+    ],
+    "slug": "faq",
+    "growthStage": "seedling",
+    "description": "Questions I am often asked to answer",
+    "outboundLinks": [
+      {
+        "matchedId": "What App is That?",
+        "title": "What App is That?",
+        "slug": "apps",
+        "growthStage": "evergreen",
+        "description": "A guide to the apps and tools I use to create illustrations"
+      },
+      {
+        "matchedId": "Drawing Invisible Programming Concepts",
+        "title": "How to Draw Invisible Programming Concepts: Part I",
+        "slug": "drawinginvisibles1",
+        "growthStage": "evergreen",
+        "description": "A case study showing how I make illustrations for abstract programming concepts"
+      }
+    ],
+    "inboundLinks": [
+      {
+        "title": "The Best Illustration Books and Courses",
+        "slug": "illustration-resources",
+        "growthStage": "evergreen",
+        "description": "My favourite resources for learning to draw and developing your visual thinking skills"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Fixed the dot separator between type label and date not being vertically centered on card components (TalkCard, NoteCard, PatternCard, NowCard)
- Reduced SVG height from 10px to 4px to match the actual circle size, and added a 1px vertical nudge for proper centering
- On NoteCard, overrode an inherited `.note-card svg { top: 4px }` rule that was pushing the dot too far down

## Test plan
- [ ] Check dot alignment on `/talks` page
- [ ] Check dot alignment on `/garden` page (note cards, pattern cards)
- [ ] Check dot alignment on `/now` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)