### PR TITLE
Remove ScrollyTalkSection side padding on mobile

### DIFF
--- a/src/components/mdx/ScrollyTalkSection.astro
+++ b/src/components/mdx/ScrollyTalkSection.astro
@@ -321,4 +321,10 @@ ${images.map((_, i) => `  [data-scrolly-id="${sectionId}"] .scrolly-text [data-s
 			padding-top: var(--space-m);
 		}
 	}
+    
+	@media (max-width: 768px) {
+		.scrolly-section {
+			padding: 0;
+		}
+	}
 </style>


### PR DESCRIPTION
## Summary
- Removes the component's own horizontal padding on small screens (≤768px) so only the parent layout padding applies
- Fixes overly narrow content in the ScrollyTalkSection at mobile viewport widths (e.g. 320px)

## Test plan
- [ ] View a talk page with ScrollyTalkSection at 320px width and confirm content is wider
- [ ] Verify spacing still looks correct at tablet (768px–1200px) and desktop widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)