### PR TITLE
Add extra bottom padding to last ScrollyTalkSection slide

### DIFF
--- a/src/components/mdx/ScrollyTalkSection.astro
+++ b/src/components/mdx/ScrollyTalkSection.astro
@@ -274,6 +274,10 @@ ${images.map((_, i) => `  [data-scrolly-id="${sectionId}"] .scrolly-text [data-s
 		margin-bottom: 0;
 	}
 
+	.scrolly-text :global([data-slide]:last-child) {
+		padding-bottom: 50vh;
+	}
+
 	/* Mobile images hidden on desktop */
 	.mobile-image {
 		display: none;
@@ -313,6 +317,10 @@ ${images.map((_, i) => `  [data-scrolly-id="${sectionId}"] .scrolly-text [data-s
 		.scrolly-text :global([data-slide]) {
 			min-height: auto;
 			padding: var(--space-m) 0;
+		}
+
+		.scrolly-text :global([data-slide]:last-child) {
+			padding-bottom: var(--space-m);
 		}
 
 		/* Override first-slide desktop offset */


### PR DESCRIPTION
## Summary

- Adds `padding-bottom: 50vh` to the last `[data-slide]` element on desktop so the scrollytelling section doesn't end abruptly
- Overrides this back to `var(--space-m)` on mobile (≤1200px) where the layout is stacked rather than sticky, so the extra whitespace doesn't create dead space

## Why

The sticky image panel stays fixed while the text scrolls. When the final text block ends, the section snaps to its bottom almost immediately — the extra padding extends the scroll distance, giving a natural continuation feel before the section ends.