### PR TITLE
Fix MobileMenu astro:before-preparation listener leak

### DIFF
--- a/src/components/layouts/navbar/MobileMenu.astro
+++ b/src/components/layouts/navbar/MobileMenu.astro
@@ -61,40 +61,30 @@ import { Icon } from "astro-icon/components";
 </style>
 
 <script>
-	function initializeMobileMenu() {
+	import { onPageLifecycle } from "../../../utils/viewTransitionLifecycle";
+
+	onPageLifecycle(() => {
 		const mobileMenu = document.getElementById("mobile-menu") as HTMLElement;
 		const links = mobileMenu?.querySelectorAll("a");
 
 		if (!mobileMenu || !links) return;
 
-		// Clean up existing listeners
-		links.forEach((link) => {
-			const existingHandler = (link as any)._mobileMenuHandler;
-			if (existingHandler) {
-				link.removeEventListener("click", existingHandler);
-			}
-		});
-
-		// Function to close mobile menu
 		const closeMobileMenu = () => {
 			mobileMenu.classList.remove("open");
 			document.body.style.overflow = "auto";
 		};
 
-		// Create and attach new handlers
 		links.forEach((link) => {
-			// Store handler for cleanup
-			(link as any)._mobileMenuHandler = closeMobileMenu;
 			link.addEventListener("click", closeMobileMenu);
 		});
 
-		// Close menu on view transition start
 		document.addEventListener("astro:before-preparation", closeMobileMenu);
-	}
 
-	// Initialize on page load
-	initializeMobileMenu();
-
-	// Re-initialize after view transitions
-	document.addEventListener("astro:page-load", initializeMobileMenu);
+		return () => {
+			links.forEach((link) => {
+				link.removeEventListener("click", closeMobileMenu);
+			});
+			document.removeEventListener("astro:before-preparation", closeMobileMenu);
+		};
+	});
 </script>


### PR DESCRIPTION
Fixes issue #2 from the view transitions audit (#40).

`MobileMenu` was registering a new `astro:before-preparation` listener on every `astro:page-load` without ever removing the old ones, causing the handler to accumulate and fire N times after N navigations. Replaced the manual re-registration pattern with the existing `onPageLifecycle` helper, which runs init on each page-load and calls the returned cleanup before the next swap — ensuring exactly one listener is active at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)