### PR TITLE
Remove Partytown, use plain GA scripts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,6 @@ import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import icon from "astro-icon";
-import partytown from "@astrojs/partytown";
 import { remarkWikiLink } from "./src/plugins/remark-wiki-link";
 
 // https://astro.build/config
@@ -20,12 +19,7 @@ export default defineConfig({
         wrap: true,
       },
     }),
-    partytown({
-      config: {
-        forward: ["dataLayer.push"],
-      },
-    }),
-    react(),
+react(),
     icon(),
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/mdx": "^4.0.1",
-        "@astrojs/partytown": "^2.1.2",
         "@astrojs/react": "^4.0.0",
         "@astrojs/rss": "^4.0.10",
         "@iconify-json/heroicons": "^1.2.1",
@@ -322,16 +321,6 @@
       },
       "peerDependencies": {
         "astro": "^5.0.0"
-      }
-    },
-    "node_modules/@astrojs/partytown": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.2.tgz",
-      "integrity": "sha512-1a9T5lqxtnrw0qLPo1KwliUvaaUzPNPtWucD8VxdwT7zqcpODFk1RzGgAgqVo+YhutFrTu/qclbtnOfXBuskjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@builder.io/partytown": "^0.10.2",
-        "mrmime": "^2.0.0"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -712,18 +701,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@builder.io/partytown": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@builder.io/partytown/-/partytown-0.10.3.tgz",
-      "integrity": "sha512-N2SWA3c5vEad3rgdAFM3zMb6uc7aXqibkgAz4ijvYzycgQXJ4dE5oH6fGFMXSQWj6ayVlLT1/CmpflYUJHfmQg==",
-      "license": "MIT",
-      "bin": {
-        "partytown": "bin/partytown.cjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@emmetio/abbreviation": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^4.0.1",
-    "@astrojs/partytown": "^2.1.2",
     "@astrojs/react": "^4.0.0",
     "@astrojs/rss": "^4.0.10",
     "@iconify-json/heroicons": "^1.2.1",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,13 +37,6 @@ if (!type) {
 	if (coverImage) ogImageURL.searchParams.set("coverImage", coverImage);
 }
 
-// Google Analytics type declarations
-declare global {
-	interface Window {
-		dataLayer: any[];
-		gtag: (...args: any[]) => void;
-	}
-}
 ---
 
 <!doctype html>
@@ -70,15 +63,6 @@ declare global {
 		<link rel="preconnect" href="https://media.maggieappleton.com" />
 		<link rel="canonical" href={canonicalURL} />
 		<ClientRouter />
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-PT3NSRSMLT"></script>
-		<script is:inline>
-			window.dataLayer = window.dataLayer || [];
-			function gtag() {
-				dataLayer.push(arguments);
-			}
-			gtag("js", new Date());
-			gtag("config", "G-PT3NSRSMLT");
-		</script>
 		<SEO
 			title={title}
 			description={desc || DEFAULT_DESCRIPTION}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -70,11 +70,8 @@ declare global {
 		<link rel="preconnect" href="https://media.maggieappleton.com" />
 		<link rel="canonical" href={canonicalURL} />
 		<ClientRouter />
-		<script
-			type="text/partytown"
-			async
-			src="https://www.googletagmanager.com/gtag/js?id=G-PT3NSRSMLT"></script>
-		<script type="text/partytown">
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-PT3NSRSMLT"></script>
+		<script is:inline>
 			window.dataLayer = window.dataLayer || [];
 			function gtag() {
 				dataLayer.push(arguments);


### PR DESCRIPTION
Removes the `@astrojs/partytown` integration entirely. Partytown was wrapping a single Google Analytics script but providing no real benefit while causing Partytown's service-worker listeners (`popstate`, `hashchange`, `pt1`, `ptupdate`, `visibilitychange`) to re-register on every SPA navigation via Astro's ClientRouter. The GA scripts are now plain `<script async>` and `is:inline`, which are inert to the view transition lifecycle. Fixes the first bug from issue #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)