### PR TITLE
Fix topic filter clicks blocked by incomplete popover cleanup

### DIFF
--- a/src/components/search/GardenFilters.astro
+++ b/src/components/search/GardenFilters.astro
@@ -302,6 +302,7 @@ const TYPES = [
 		box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
 		opacity: 0;
 		transform: translateY(-4px);
+		pointer-events: none;
 		transition:
 			opacity 160ms ease-out,
 			transform 160ms ease-out;
@@ -312,6 +313,7 @@ const TYPES = [
 	.filter-popover[data-open="true"] .filter-panel {
 		opacity: 1;
 		transform: translateY(0);
+		pointer-events: auto;
 	}
 	@media (prefers-reduced-motion: reduce) {
 		.filter-panel {
@@ -907,7 +909,7 @@ const TYPES = [
 		filterState.types = [];
 
 		const topicsList = document.querySelector<HTMLElement>(".topics-list");
-		const filterPopovers = document.querySelector(".right-menus");
+		const filterPopovers = document.querySelector<HTMLElement>(".right-menus");
 		const leftBtn = document.getElementById("scroll-left") as HTMLElement;
 		const rightBtn = document.getElementById("scroll-right") as HTMLElement;
 
@@ -918,20 +920,15 @@ const TYPES = [
 
 		syncUI();
 
+		let onScroll: (() => void) | undefined;
 		if (topicsList && leftBtn && rightBtn) {
 			updateScrollButtons(topicsList, leftBtn, rightBtn);
 
-			const onScroll = () => updateScrollButtons(topicsList, leftBtn, rightBtn);
+			onScroll = () => updateScrollButtons(topicsList, leftBtn, rightBtn);
 			topicsList.addEventListener("scroll", onScroll, { passive: true });
 
 			leftBtn.addEventListener("click", () => topicsList.scrollBy({ left: -160, behavior: "smooth" }));
 			rightBtn.addEventListener("click", () => topicsList.scrollBy({ left: 160, behavior: "smooth" }));
-
-			return () => {
-				topicsList.removeEventListener("click", handleTopicClick);
-				rightMenus?.removeEventListener("change", handleSelectChange);
-				topicsList.removeEventListener("scroll", onScroll);
-			};
 		}
 
 		return () => {
@@ -939,6 +936,7 @@ const TYPES = [
 			filterPopovers?.removeEventListener("click", handlePopoverClick);
 			document.removeEventListener("click", handleDocumentClick);
 			document.removeEventListener("keydown", handleKeydown);
+			if (onScroll) topicsList?.removeEventListener("scroll", onScroll);
 		};
 	});
 </script>


### PR DESCRIPTION
## Summary

- Adds `pointer-events: none` to `.filter-panel` when closed, so the invisibly-transitioning panel can't intercept clicks on topic buttons during the 120ms close animation
- Fixes the `onPageLifecycle` cleanup to remove all event listeners — `filterPopovers` and `document` listeners were missing from the early-return path, causing duplicates on each `astro:page-load` re-init (which fires on every navigation including first load)
- Removes stale `rightMenus`/`handleSelectChange` references left over from a prior refactor

## Test plan

- [ ] Go to the Garden page via a view-transition navigation (e.g. from Home)
- [ ] Open and interact with the Growth Stages filter
- [ ] Open and interact with the Types filter
- [ ] Confirm topic filter buttons are clickable and apply correctly
- [ ] Confirm popovers open/close normally and multi-select Types works without toggling back off

🤖 Generated with [Claude Code](https://claude.com/claude-code)