### PR TITLE
[ai] Fix per-image load listener leak in ScrollyTalkSection

### DIFF
--- a/src/components/mdx/ScrollyTalkSection.astro
+++ b/src/components/mdx/ScrollyTalkSection.astro
@@ -175,7 +175,7 @@ ${images.map((_, i) => `  [data-scrolly-id="${sectionId}"] .scrolly-text [data-s
 		initAllScrollySections();
 		window.addEventListener("resize", handleResize);
 		document.querySelectorAll(".scrolly-img").forEach((img) => {
-			img.addEventListener("load", handleResize);
+			img.addEventListener("load", handleResize, { once: true });
 		});
 	}
 


### PR DESCRIPTION
## Implements

Closes #48

## Parent plan

#46

## What changed

- Added `{ once: true }` option to the `.scrolly-img` `load` event listener in `ScrollyTalkSection.astro:178`
- Each listener now auto-removes itself after firing once, preventing accumulation on persisted DOM subtrees across SPA navigations
- The existing `window` resize listener and its cleanup via `astro:before-swap` / `astro:unmount` are unchanged

## How to verify

1. Navigate to any page that includes a `ScrollyTalkSection` component
2. Navigate away via an SPA link, then navigate back (repeat 2–3 times)
3. Open DevTools → Elements → select a `.scrolly-img` element → Event Listeners panel — confirm only one `load` listener (or none if already fired), not an accumulating stack
4. Confirm the scrolly-talk layout still initialises correctly after each round-trip and that window resize still triggers re-layout

## Notes

`{ once: true }` is the minimal correct fix here: `handleResize` is only needed when an image first completes loading after a page-load cycle, so there is no scenario that requires the handler to fire more than once per element per navigation. The stateful array teardown alternative would have been more code for no additional benefit.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/24933386909/agentic_workflow) for issue #48 · ● 48.5K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 24933386909, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/24933386909 -->

<!-- gh-aw-workflow-id: implementer -->