### PR TITLE
[ai] Fix Twitter widgets.js redundant re-injection on SPA navigation

### DIFF
--- a/src/components/mdx/TweetEmbed.astro
+++ b/src/components/mdx/TweetEmbed.astro
@@ -16,30 +16,19 @@ const { tweetId } = Astro.props;
 	}
 
 	function loadTwitterWidget() {
-		// Remove any existing Twitter script to prevent duplicates
-		const existingScript = document.querySelector(
-			'script[src="https://platform.twitter.com/widgets.js"]',
-		);
-		if (existingScript) {
-			existingScript.remove();
-		}
-
-		// Create and append new Twitter script
-		const script = document.createElement("script");
-		script.src = "https://platform.twitter.com/widgets.js";
-		script.async = true;
-		document.body.appendChild(script);
-
-		// Force widget load if window.twttr exists
 		if (window.twttr) {
+			// Script already loaded — just re-process any new tweet embeds on the page
 			window.twttr.widgets.load();
+		} else if (!document.querySelector('script[src="https://platform.twitter.com/widgets.js"]')) {
+			// First time on a tweet-containing page — inject the script once
+			const script = document.createElement("script");
+			script.src = "https://platform.twitter.com/widgets.js";
+			script.async = true;
+			document.body.appendChild(script);
 		}
 	}
 
-	// Initialize on first load
-	loadTwitterWidget();
-
-	// Re-initialize after view transitions
+	// Initialize on first load and after each SPA navigation
 	document.addEventListener("astro:page-load", loadTwitterWidget);
 </script>
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -105,6 +105,5 @@ if (!type) {
 				content-visibility: auto;
 			}
 		</style>
-		<script async src="https://platform.twitter.com/widgets.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
## Implements

Closes #49

## Parent plan

#46

## What changed

- **Removed** the global `<script async src="(platform.twitter.com/redacted) from `src/layouts/Layout.astro` — it was loaded on every page including tweet-free ones, and replaced on every SPA navigation.
- **Rewrote** `loadTwitterWidget` in `src/components/mdx/TweetEmbed.astro`: on `astro:page-load`, if `window.twttr` is already present call `window.twttr.widgets.load()` to process new embeds; otherwise inject the `<script>` tag once (guarded by a `querySelector` check so multiple `TweetEmbed` components on the same page don't race to inject duplicates).
- Removed the redundant direct call to `loadTwitterWidget()` at module scope — the `astro:page-load` listener fires on first load too, so the explicit call was unnecessary.

## How to verify

1. Open DevTools Network tab, filter by `widgets.js`.
2. Navigate to a page with tweet embeds — verify `widgets.js` is fetched once and tweets render.
3. SPA-navigate to another tweet page — verify `widgets.js` is **not** re-requested (304 or absent) and tweets still render.
4. Navigate to a page with **no** tweets — verify `widgets.js` is not requested at all.

## Notes

The `querySelector` guard in the `else if` branch handles the edge case where the page fires `astro:page-load` before `window.twttr` has been initialised (script injected but not yet executed). In that case, widgets.js is already in the DOM so no second injection happens; Twitter's own script will call `widgets.load()` on startup and pick up the embeds itself.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/24933387449/agentic_workflow) for issue #49 · ● 125.3K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 24933387449, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/24933387449 -->

<!-- gh-aw-workflow-id: implementer -->