### PR TITLE
[ai] Fix resize-listener leak in scrollama and GSAP components after SPA navigation

### DIFF
--- a/src/components/mdx/ScrollyTalkSection.astro
+++ b/src/components/mdx/ScrollyTalkSection.astro
@@ -127,12 +127,10 @@ ${images.map((_, i) => `  [data-scrolly-id="${sectionId}"] .scrolly-text [data-s
 
 <script>
 	import scrollama from "scrollama";
+	import { onPageLifecycle } from "../../utils/viewTransitionLifecycle";
 
-	const scrollers: any[] = [];
-
-	function initAllScrollySections() {
-		scrollers.forEach((s) => s.destroy());
-		scrollers.length = 0;
+	onPageLifecycle(() => {
+		const scrollers: any[] = [];
 
 		document.querySelectorAll("[data-scrolly-id]").forEach((section) => {
 			const images = section.querySelectorAll(".scrolly-img");
@@ -167,29 +165,19 @@ ${images.map((_, i) => `  [data-scrolly-id="${sectionId}"] .scrolly-text [data-s
 
 			scrollers.push(scroller);
 		});
-	}
 
-	const handleResize = () => scrollers.forEach((s) => s.resize());
-
-	function initAndAttachListeners() {
-		initAllScrollySections();
+		const handleResize = () => scrollers.forEach((s) => s.resize());
 		window.addEventListener("resize", handleResize);
+		// Note: per-image load listeners are tracked separately in issue #46 item 2
 		document.querySelectorAll(".scrolly-img").forEach((img) => {
 			img.addEventListener("load", handleResize);
 		});
-	}
 
-	initAndAttachListeners();
-
-	document.addEventListener("astro:page-load", initAndAttachListeners);
-
-	const cleanup = () => {
-		scrollers.forEach((s) => s.destroy());
-		scrollers.length = 0;
-		window.removeEventListener("resize", handleResize);
-	};
-	document.addEventListener("astro:before-swap", cleanup);
-	document.addEventListener("astro:unmount", cleanup);
+		return () => {
+			scrollers.forEach((s) => s.destroy());
+			window.removeEventListener("resize", handleResize);
+		};
+	});
 </script>
 
 <style>

--- a/src/components/unique/ScrollingImages.astro
+++ b/src/components/unique/ScrollingImages.astro
@@ -37,12 +37,13 @@ if (!data || data.length === 0) {
 
 <script>
 	import scrollama from "scrollama";
+	import { onPageLifecycle } from "../../utils/viewTransitionLifecycle";
 
-	let scroller: any;
-	let fadeImages: NodeListOf<HTMLImageElement>;
-	let currentStep = -1;
+	onPageLifecycle(() => {
+		let scroller: any;
+		let fadeImages: NodeListOf<HTMLImageElement>;
+		let currentStep = -1;
 
-	function initScrollama() {
 		scroller = scrollama();
 		fadeImages = document.querySelectorAll(".fade-image");
 
@@ -81,26 +82,15 @@ if (!data || data.length === 0) {
 					});
 				}
 			});
-	}
 
-	// Initial setup
-	initScrollama();
+		const handleResize = () => scroller?.resize();
+		window.addEventListener("resize", handleResize);
 
-	// Handle resize
-	const handleResize = () => scroller?.resize();
-	window.addEventListener("resize", handleResize);
-
-	// Reinit on view transitions
-	document.addEventListener("astro:page-load", initScrollama);
-
-	// Cleanup
-	const cleanup = () => {
-		scroller?.destroy();
-		window.removeEventListener("resize", handleResize);
-	};
-
-	document.addEventListener("astro:before-swap", cleanup);
-	document.addEventListener("astro:unmount", cleanup);
+		return () => {
+			scroller?.destroy();
+			window.removeEventListener("resize", handleResize);
+		};
+	});
 </script>
 
 <style>

--- a/src/components/unique/TweenBox.astro
+++ b/src/components/unique/TweenBox.astro
@@ -7,19 +7,13 @@
 </div>
 
 <script>
-	let currentObserver: IntersectionObserver | null = null;
+	import { onPageLifecycle } from "../../utils/viewTransitionLifecycle";
 
-	function initializeObserver() {
-		// Clean up existing observer
-		if (currentObserver) {
-			currentObserver.disconnect();
-			currentObserver = null;
-		}
-
+	onPageLifecycle(() => {
 		const boxes = document.querySelectorAll(".animated-box");
 		if (boxes.length === 0) return;
 
-		currentObserver = new IntersectionObserver(
+		const observer = new IntersectionObserver(
 			(entries) => {
 				entries.forEach((entry) => {
 					if (entry.isIntersecting) {
@@ -29,30 +23,12 @@
 					}
 				});
 			},
-			{
-				threshold: 0.6,
-				rootMargin: "0px",
-			},
+			{ threshold: 0.6, rootMargin: "0px" },
 		);
 
-		boxes.forEach((box) => currentObserver?.observe(box));
-	}
-
-	function cleanup() {
-		if (currentObserver) {
-			currentObserver.disconnect();
-			currentObserver = null;
-		}
-	}
-
-	// Initialize on first load
-	initializeObserver();
-
-	// Reinitialize after view transitions
-	document.addEventListener("astro:page-load", initializeObserver);
-
-	// Cleanup on page leave
-	document.addEventListener("astro:before-swap", cleanup);
+		boxes.forEach((box) => observer.observe(box));
+		return () => observer.disconnect();
+	});
 </script>
 
 <style>

--- a/src/components/unique/gsap-basics/GsapScroller.astro
+++ b/src/components/unique/gsap-basics/GsapScroller.astro
@@ -35,12 +35,13 @@
 
 <script>
 	import scrollama from "scrollama";
+	import { onPageLifecycle } from "../../../utils/viewTransitionLifecycle";
 
-	let scroller: any;
-	let fadeImages: NodeListOf<Element>;
-	let currentStep = -1;
+	onPageLifecycle(() => {
+		let scroller: any;
+		let fadeImages: NodeListOf<Element>;
+		let currentStep = -1;
 
-	function initScrollama() {
 		scroller = scrollama();
 		fadeImages = document.querySelectorAll(".fade-image");
 
@@ -66,26 +67,15 @@
 					});
 				}
 			});
-	}
 
-	// Initial setup
-	initScrollama();
+		const handleResize = () => scroller?.resize();
+		window.addEventListener("resize", handleResize);
 
-	// Handle resize
-	const handleResize = () => scroller?.resize();
-	window.addEventListener("resize", handleResize);
-
-	// Reinit on view transitions
-	document.addEventListener("astro:page-load", initScrollama);
-
-	// Cleanup
-	const cleanup = () => {
-		scroller?.destroy();
-		window.removeEventListener("resize", handleResize);
-	};
-
-	document.addEventListener("astro:before-swap", cleanup);
-	document.addEventListener("astro:unmount", cleanup);
+		return () => {
+			scroller?.destroy();
+			window.removeEventListener("resize", handleResize);
+		};
+	});
 </script>
 
 <style>

--- a/src/components/unique/gsap-basics/TweenBlueRedBox.astro
+++ b/src/components/unique/gsap-basics/TweenBlueRedBox.astro
@@ -1,19 +1,13 @@
 <div class="box" id="color-box"></div>
 
 <script>
-	let currentObserver: IntersectionObserver | null = null;
+	import { onPageLifecycle } from "../../../utils/viewTransitionLifecycle";
 
-	function initializeObserver() {
-		// Clean up existing observer
-		if (currentObserver) {
-			currentObserver.disconnect();
-			currentObserver = null;
-		}
-
+	onPageLifecycle(() => {
 		const box = document.getElementById("color-box");
 		if (!box) return;
 
-		currentObserver = new IntersectionObserver(
+		const observer = new IntersectionObserver(
 			([entry]) => {
 				if (entry.isIntersecting) {
 					box.classList.add("animate");
@@ -21,30 +15,12 @@
 					box.classList.remove("animate");
 				}
 			},
-			{
-				threshold: 0.5,
-				rootMargin: "-30% 0px",
-			},
+			{ threshold: 0.5, rootMargin: "-30% 0px" },
 		);
 
-		currentObserver.observe(box);
-	}
-
-	function cleanup() {
-		if (currentObserver) {
-			currentObserver.disconnect();
-			currentObserver = null;
-		}
-	}
-
-	// Initialize on first load
-	initializeObserver();
-
-	// Reinitialize after view transitions
-	document.addEventListener("astro:page-load", initializeObserver);
-
-	// Cleanup on page leave
-	document.addEventListener("astro:before-swap", cleanup);
+		observer.observe(box);
+		return () => observer.disconnect();
+	});
 </script>
 
 <style>

--- a/src/components/unique/gsap-basics/TweenRedBigBox.astro
+++ b/src/components/unique/gsap-basics/TweenRedBigBox.astro
@@ -5,19 +5,13 @@
 <div class="box" id="scaling-box"></div>
 
 <script>
-	let currentObserver: IntersectionObserver | null = null;
+	import { onPageLifecycle } from "../../../utils/viewTransitionLifecycle";
 
-	function initializeObserver() {
-		// Clean up existing observer
-		if (currentObserver) {
-			currentObserver.disconnect();
-			currentObserver = null;
-		}
-
+	onPageLifecycle(() => {
 		const box = document.getElementById("scaling-box");
 		if (!box) return;
 
-		currentObserver = new IntersectionObserver(
+		const observer = new IntersectionObserver(
 			([entry]) => {
 				if (entry.isIntersecting) {
 					box.classList.add("animate");
@@ -25,30 +19,12 @@
 					box.classList.remove("animate");
 				}
 			},
-			{
-				threshold: 0.2,
-				rootMargin: "-30% 0px",
-			},
+			{ threshold: 0.2, rootMargin: "-30% 0px" },
 		);
 
-		currentObserver.observe(box);
-	}
-
-	function cleanup() {
-		if (currentObserver) {
-			currentObserver.disconnect();
-			currentObserver = null;
-		}
-	}
-
-	// Initialize on first load
-	initializeObserver();
-
-	// Reinitialize after view transitions
-	document.addEventListener("astro:page-load", initializeObserver);
-
-	// Cleanup on page leave
-	document.addEventListener("astro:before-swap", cleanup);
+		observer.observe(box);
+		return () => observer.disconnect();
+	});
 </script>
 
 <style>

--- a/src/components/unique/gsap-basics/TweenReverseSpinningBox.astro
+++ b/src/components/unique/gsap-basics/TweenReverseSpinningBox.astro
@@ -5,48 +5,24 @@
 <div class="box" id="reverse-spinning-box"></div>
 
 <script>
-	let currentObserver: IntersectionObserver | null = null;
+	import { onPageLifecycle } from "../../../utils/viewTransitionLifecycle";
 
-	function initializeObserver() {
-		// Clean up existing observer
-		if (currentObserver) {
-			currentObserver.disconnect();
-			currentObserver = null;
-		}
-
+	onPageLifecycle(() => {
 		const box = document.getElementById("reverse-spinning-box");
 		if (!box) return;
 
-		currentObserver = new IntersectionObserver(
+		const observer = new IntersectionObserver(
 			([entry]) => {
 				if (entry.isIntersecting) {
 					box.classList.add("animate");
 				}
 			},
-			{
-				threshold: 0.2,
-				rootMargin: "-30% 0px",
-			},
+			{ threshold: 0.2, rootMargin: "-30% 0px" },
 		);
 
-		currentObserver.observe(box);
-	}
-
-	function cleanup() {
-		if (currentObserver) {
-			currentObserver.disconnect();
-			currentObserver = null;
-		}
-	}
-
-	// Initialize on first load
-	initializeObserver();
-
-	// Reinitialize after view transitions
-	document.addEventListener("astro:page-load", initializeObserver);
-
-	// Cleanup on page leave
-	document.addEventListener("astro:before-swap", cleanup);
+		observer.observe(box);
+		return () => observer.disconnect();
+	});
 </script>
 
 <style>

--- a/src/components/unique/gsap-basics/TweenSpinningBox.astro
+++ b/src/components/unique/gsap-basics/TweenSpinningBox.astro
@@ -5,19 +5,13 @@
 <div class="box" id="spinning-box"></div>
 
 <script>
-	let currentObserver: IntersectionObserver | null = null;
+	import { onPageLifecycle } from "../../../utils/viewTransitionLifecycle";
 
-	function initializeObserver() {
-		// Clean up existing observer
-		if (currentObserver) {
-			currentObserver.disconnect();
-			currentObserver = null;
-		}
-
+	onPageLifecycle(() => {
 		const box = document.getElementById("spinning-box");
 		if (!box) return;
 
-		currentObserver = new IntersectionObserver(
+		const observer = new IntersectionObserver(
 			([entry]) => {
 				if (entry.isIntersecting) {
 					box.classList.add("animate");
@@ -25,30 +19,12 @@
 					box.classList.remove("animate");
 				}
 			},
-			{
-				threshold: 0.2,
-				rootMargin: "-30% 0px",
-			},
+			{ threshold: 0.2, rootMargin: "-30% 0px" },
 		);
 
-		currentObserver.observe(box);
-	}
-
-	function cleanup() {
-		if (currentObserver) {
-			currentObserver.disconnect();
-			currentObserver = null;
-		}
-	}
-
-	// Initialize on first load
-	initializeObserver();
-
-	// Reinitialize after view transitions
-	document.addEventListener("astro:page-load", initializeObserver);
-
-	// Cleanup on page leave
-	document.addEventListener("astro:before-swap", cleanup);
+		observer.observe(box);
+		return () => observer.disconnect();
+	});
 </script>
 
 <style>


### PR DESCRIPTION
## Implements

Closes #47

## Parent plan

#46

## What changed

- **`ScrollingImages.astro` and `GsapScroller.astro`**: The core bug fix — `window.addEventListener("resize", handleResize)` was called at module scope (once on first load) but removed in `astro:before-swap` cleanup. After any SPA navigation away and back, the resize listener was never re-added, so scrollama's layout calculations broke on resize. Both files now use `onPageLifecycle` so the listener is attached and removed within the same page-load cycle.
- **`TweenSpinningBox`, `TweenBlueRedBox`, `TweenRedBigBox`, `TweenReverseSpinningBox`, `TweenBox`**: Converted from manual `initializeObserver` / `cleanup` + `astro:page-load` / `astro:before-swap` event listeners to `onPageLifecycle`. No resize listener was present in these files, but the conversion removes module-level mutable state and makes the lifecycle management consistent with the rest of the codebase.
- **`ScrollyTalkSection.astro`** (resize portion): Converted to `onPageLifecycle`, moving `scrollers` state and `handleResize` inside the callback so each page-load cycle gets a fresh, self-contained attach/cleanup pair. Per-image `load` listener cleanup is out of scope here (tracked separately as item 2 in #46).

## How to verify

- Visit a page using `ScrollingImages` or `GsapScroller` (e.g. the GSAP basics essay), navigate away via an SPA link, navigate back, then resize the browser window — the scroll-driven image transitions should still respond correctly.
- Open DevTools → Performance → Event Listeners, filter for `resize` on `window`, and confirm the count stays at 1 (or 0 when off the page) across repeated back-and-forth navigations.
- Confirm GSAP animation components (spinning box, color box, etc.) still trigger their CSS transitions on scroll after SPA navigation.

## Notes

- `onPageLifecycle` calls cleanup before each re-init, so the destroy/re-create cycle is safe. The `scrollers.length = 0` reset in the old `ScrollyTalkSection` code is no longer needed since `scrollers` is now a local array recreated each cycle.
- The `astro:unmount` listeners present in the old `ScrollingImages` and `GsapScroller` code are not reproduced — `onPageLifecycle` handles `astro:before-swap` only, which is sufficient for page-scoped components.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/24933386921/agentic_workflow) for issue #47 · ● 410.9K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 24933386921, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/24933386921 -->

<!-- gh-aw-workflow-id: implementer -->