### PR TITLE
Fix remaining low-priority view-transition bugs (#40)

### DIFF
--- a/src/components/cards/EssayCard.astro
+++ b/src/components/cards/EssayCard.astro
@@ -21,7 +21,7 @@ import GrowthIcon from "../layouts/GrowthIcon.astro";
 				</div>
 			)
 		}
-		<h3 transition:name={`title-${slug}`}>{title}</h3>
+		<h3 transition:name={`title-${id}`}>{title}</h3>
 		<p class="description">{description}</p>
 		<div class="metadata-container">
 			{growthStage && <span>Essay</span>}

--- a/src/components/unique/ChatHistoryTabs.astro
+++ b/src/components/unique/ChatHistoryTabs.astro
@@ -56,9 +56,13 @@ const {
 				if (activeImage.complete) {
 					stack.style.height = `${activeImage.offsetHeight}px`;
 				} else {
-					activeImage.addEventListener("load", () => {
-						stack.style.height = `${activeImage.offsetHeight}px`;
-					});
+					activeImage.addEventListener(
+						"load",
+						() => {
+							stack.style.height = `${activeImage.offsetHeight}px`;
+						},
+						{ once: true },
+					);
 				}
 			}
 		}


### PR DESCRIPTION
Closes the last two actionable items from #40.

## Summary
- **EssayCard `transition:name` collision (item #8)**: switched the transition name from `title-${slug}` to `title-${id}`. The slug is produced by `extractBaseSlug()`, which strips version suffixes — so two versions of the same essay in one list would share a `view-transition-name` and abort the transition. Using `id` keeps version info and guarantees uniqueness. Not visibly broken today (no list mixes versions), but the fix removes the latent fragility.
- **ChatHistoryTabs `load` listener accumulation (item #6)**: added `{ once: true }` so each tab switch doesn't pile up `load` handlers on the same image when the user toggles before load completes.
- **WebMentions state preservation (item #9)**: intentionally **not** changed — the audit classifies it as a UX choice, not a bug.

## Test plan
- [ ] `/essays` and `/garden` still render essay cards and the title element animates between list and detail views.
- [ ] Visit a page with `<ChatHistoryTabs />`, click between Claude/ChatGPT tabs rapidly; container height adjusts and no console warnings appear.
- [ ] No `view-transition-name` console warnings on `/essays`, `/garden`, or topic pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)