### PR TITLE
Fix evergreen and budding growth icons not rendering on cards

### DIFF
--- a/src/icons/budding.svg
+++ b/src/icons/budding.svg
@@ -3,17 +3,12 @@
     xmlns="http://www.w3.org/2000/svg"
     preserveAspectRatio="xMinYMin meet"
     viewBox="0 0 25 25">
-    <style>
-        .budding__cls-1 {
-            fill: var(--color-sea-blue);
-        }
-    </style>
     <path
-        class="budding__cls-1"
+        fill="var(--color-sea-blue)"
         d="M12.79 18.34a.41.41 0 01-.59 0c-4-4.22-4-12.11 0-16.32a.4.4 0 01.59 0c4.06 4.21 4.06 12.1 0 16.32z"
     />
     <path
-        class="budding__cls-1"
+        fill="var(--color-sea-blue)"
         d="M12.21 21.89a12.63 12.63 0 00-11.4-9.16.3.3 0 00-.31.33 11.67 11.67 0 0012 10h.06a11.67 11.67 0 0012-10 .3.3 0 00-.31-.33 12.63 12.63 0 00-11.4 9.16.3.3 0 01-.64 0z"
     />
     <path fill="none" d="M0 0h25v25H0z" />

--- a/src/icons/evergreen.svg
+++ b/src/icons/evergreen.svg
@@ -3,19 +3,14 @@
     xmlns="http://www.w3.org/2000/svg"
     preserveAspectRatio="xMinYMin meet"
     viewBox="0 0 25 25">
-    <style>
-        .evergreen__cls-1 {
-            fill: var(--color-sea-blue);
-        }
-    </style>
     <path
-        class="evergreen__cls-1"
+        fill="var(--color-sea-blue)"
         d="M12.76 15.45a.36.36 0 01-.52 0c-3.59-3.74-3.6-10.73 0-14.45a.36.36 0 01.52 0c3.59 3.72 3.6 10.71 0 14.45z"/>
     <path
-        class="evergreen__cls-1"
+        fill="var(--color-sea-blue)"
         d="M12.25 18.61a11.21 11.21 0 00-10.12-8.13.26.26 0 00-.27.29 10.36 10.36 0 0010.61 8.91h.06a10.36 10.36 0 0010.61-8.91.26.26 0 00-.27-.29 11.21 11.21 0 00-10.12 8.13.26.26 0 01-.5 0z"/>
     <path
-        class="evergreen__cls-1"
+        fill="var(--color-sea-blue)"
         d="M24.17 24.1a.33.33 0 00.32-.42 6.21 6.21 0 00-6-4.22 6.3 6.3 0 00-5.7 3.44.32.32 0 01-.58 0 6.3 6.3 0 00-5.7-3.44 6.21 6.21 0 00-6 4.22.33.33 0 00.32.42H12.5z"/>
     <path fill="none" d="M0 0h25v25H0z"/>
 </svg>


### PR DESCRIPTION
## Summary
The evergreen growth-stage icon (and budding, which has the same latent bug) wasn't rendering next to note titles on topic and listing pages.

## Root cause
`astro-icon` defines each icon's `<symbol>` once at its first page-level usage and references it via `<use href="#...">` everywhere else. The first `evergreen` icon on every page lives inside `MainNavLinks.astro`'s megamenu, and Astro scopes any `<style>` block found within a component — rewriting the icon's inline `.evergreen__cls-1 { fill: ... }` rule to `.evergreen__cls-1[data-astro-cid-cthrxkdi]`. The cloned paths inside `<use>` shadow trees don't carry that scoping attribute, so the rule never matched and paths rendered with no fill.

## Fix
Replaced the `<style>` + class pattern in `evergreen.svg` and `budding.svg` with inline `fill="var(--color-sea-blue)"` attributes on each path, matching the existing `seedling.svg` pattern, which is immune to Astro's style scoping.