### PR TITLE
[ai] Remove h2 color transition

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -474,7 +474,6 @@ h2 {
   font-weight: 100;
   line-height: var(--leading-snug);
   margin: var(--space-xs) 0 var(--space-2xs);
-  transition: all 0.3s ease-in-out;
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
## Implements

Closes #64

## Parent plan

#56

## What changed

- Removed `transition: all 0.3s ease-in-out` from the `h2` rule in `src/global.css:477`
- h2 headings have no animated state changes (no hover, focus, or active variants), so the transition was a no-op that silently animated any color/layout change touching h2

## How to verify

- Browse any page with h2 headings (e.g. an essay page) — headings should render identically with no visible difference
- Confirm no `transition` property remains on the base `h2` rule in `src/global.css`

## Notes

One-line deletion; zero behavior change since h2 had no styled state transitions to animate. Part of the broader `transition: all` sweep described in the animation audit (#56 §2.2).




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/24965006812/agentic_workflow) for issue #64 · ● 63.6K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 24965006812, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/24965006812 -->

<!-- gh-aw-workflow-id: implementer -->