### PR TITLE
[ai] Stop skeleton pulse animation on image load

### DIFF
--- a/src/components/mdx/BasicImage.astro
+++ b/src/components/mdx/BasicImage.astro
@@ -122,6 +122,10 @@ const isImageMetadata = typeof imageSrc !== "string" && "src" in imageSrc;
         animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
     }
 
+    .image-wrapper.loaded::before {
+        animation: none;
+    }
+
     @keyframes pulse {
         0%,
         100% {
@@ -168,3 +172,16 @@ const isImageMetadata = typeof imageSrc !== "string" && "src" in imageSrc;
         }
     }
 </style>
+
+<script>
+    document.querySelectorAll<HTMLElement>(".image-wrapper").forEach((wrapper) => {
+        const img = wrapper.querySelector("img");
+        if (!img) return;
+        const stopPulse = () => wrapper.classList.add("loaded");
+        if (img.complete) {
+            stopPulse();
+        } else {
+            img.addEventListener("load", stopPulse, { once: true });
+        }
+    });
+</script>


### PR DESCRIPTION
## Implements

Closes #69

## Parent plan

#56

## What changed

- Added `.image-wrapper.loaded::before { animation: none; }` CSS rule to halt the pulse keyframe when the image is done loading
- Added a `<script>` block that queries all `.image-wrapper` elements on the page and attaches a `load` listener to each contained `<img>`
- The listener adds the `loaded` class (removing the animation) and fires with `{ once: true }` so it auto-cleans up
- Handles already-cached images via `img.complete` — the class is applied synchronously if the image is already decoded

## How to verify

1. Open any essay page with `<BasicImage>` components
2. In DevTools → Performance (or Animations panel), confirm no active `pulse` animation on `.image-wrapper::before` after the image has loaded
3. Throttle the network to Slow 3G, reload — the skeleton should visibly pulse while the image is loading, then stop once the `load` event fires

## Notes

- Pseudo-elements can't be targeted by JS directly; toggling a class on the parent wrapper is the standard pattern
- The `{ once: true }` option means the event listener removes itself after firing — no cleanup needed
- Astro bundles `<script>` blocks globally; `querySelectorAll` handles all instances of the component on a single page




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/24965015497/agentic_workflow) for issue #69 · ● 98.8K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 24965015497, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/24965015497 -->

<!-- gh-aw-workflow-id: implementer -->