### PR TITLE
Add security headers and block AI crawlers

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,45 @@
+User-agent: *
+Allow: /
+
+# AI training crawlers
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: YouBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,33 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://platform.twitter.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://res.cloudinary.com https://*.twimg.com https://pbs.twimg.com; font-src 'self'; frame-src https://twitter.com https://platform.twitter.com; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with HTTP security headers applied to all routes
- Adds `public/robots.txt` that blocks known AI training crawlers

## Security headers added

| Header | Value |
|---|---|
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` |
| `X-Frame-Options` | `SAMEORIGIN` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |
| `Content-Security-Policy` | Allows self + Twitter scripts/frames, Cloudinary images; blocks everything else |

The CSP accounts for Astro inline hydration scripts (`unsafe-inline`), Shiki inline styles, Twitter/X embeds via `astro-embed`, and Cloudinary image CDN.

## AI crawlers blocked

GPTBot, ChatGPT-User, anthropic-ai, Claude-Web, CCBot, Google-Extended, PerplexityBot, YouBot, Bytespider, Diffbot, cohere-ai, FacebookBot, Applebot-Extended, Omgilibot.

## Test plan

- [ ] Deploy to Vercel preview and run `curl -I <preview-url>` to verify headers are present
- [ ] Open a page with a Twitter embed in DevTools console — confirm no CSP violations
- [ ] Confirm Cloudinary images load on essay pages
- [ ] Verify `robots.txt` is accessible at `/robots.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)