### PR TITLE
fix CSP to unblock YouTube, Vimeo, Figma, R2 videos, and webmention avatars

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,7 +25,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://platform.twitter.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://res.cloudinary.com https://*.twimg.com https://pbs.twimg.com https://i.ytimg.com; font-src 'self'; frame-src https://twitter.com https://platform.twitter.com https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://platform.twitter.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://res.cloudinary.com https://*.twimg.com https://pbs.twimg.com https://i.ytimg.com https://media.maggieappleton.com https://avatars.webmention.io https://d2eip9sf3oo6c2.cloudfront.net https://*.cdn.getcloudapp.com; font-src 'self'; media-src 'self' https://media.maggieappleton.com; frame-src https://twitter.com https://platform.twitter.com https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://www.figma.com; connect-src 'self' https://syndication.twitter.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -25,7 +25,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://platform.twitter.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://res.cloudinary.com https://*.twimg.com https://pbs.twimg.com; font-src 'self'; frame-src https://twitter.com https://platform.twitter.com; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://platform.twitter.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://res.cloudinary.com https://*.twimg.com https://pbs.twimg.com https://i.ytimg.com; font-src 'self'; frame-src https://twitter.com https://platform.twitter.com https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
         }
       ]
     }


### PR DESCRIPTION
## Summary

PR #76 introduced a Content-Security-Policy that was too strict and silently broke several embeds and assets across the site. The reported symptom was YouTube embeds being blocked, but an audit found more.

### Fixes

**Iframes (`frame-src`)**
- `www.youtube.com` + `www.youtube-nocookie.com` — talk page YouTube embeds
- `player.vimeo.com` — `talks/squish-structure`
- `www.figma.com` — `essays/transcopyright-dreams`

**Videos (`media-src` + `img-src`)**
- `media.maggieappleton.com` — R2-hosted `.mp4`s used across talk pages (e.g. all 13 videos in `talks/zero-alignment`)

**Scripts (`script-src`)**
- `cdn.jsdelivr.net` — d3 ESM import in `birth-probability/ProbabilityChart.astro`

**Images (`img-src`)**
- `i.ytimg.com` — YouTube thumbnail posters
- `avatars.webmention.io` — webmention profile pics on every post with mentions
- `d2eip9sf3oo6c2.cloudfront.net` — Egghead course covers in `drawinginvisibles1`
- `*.cdn.getcloudapp.com` — image in `transcopyright-dreams`

**Connect (`connect-src`)**
- `syndication.twitter.com` — Twitter widget hydration calls

## Test plan

- [ ] Open a talk page (e.g. `/talks/zero-alignment`) — R2 videos + YouTube embed should load
- [ ] `/talks/squish-structure` — Vimeo should load
- [ ] `/essays/transcopyright-dreams` — Figma prototype iframes should load
- [ ] A post with webmentions — avatar pics should load (no broken image icons)
- [ ] DevTools console clear of CSP violations on each page

🤖 Generated with [Claude Code](https://claude.com/claude-code)