### PR TITLE
allow Google Fonts in CSP so Lato loads

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,7 +25,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://platform.twitter.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://res.cloudinary.com https://*.twimg.com https://pbs.twimg.com https://i.ytimg.com https://media.maggieappleton.com https://avatars.webmention.io https://d2eip9sf3oo6c2.cloudfront.net https://*.cdn.getcloudapp.com; font-src 'self'; media-src 'self' https://media.maggieappleton.com; frame-src https://twitter.com https://platform.twitter.com https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://www.figma.com; connect-src 'self' https://syndication.twitter.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://platform.twitter.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://res.cloudinary.com https://*.twimg.com https://pbs.twimg.com https://i.ytimg.com https://media.maggieappleton.com https://avatars.webmention.io https://d2eip9sf3oo6c2.cloudfront.net https://*.cdn.getcloudapp.com; font-src 'self' https://fonts.gstatic.com; media-src 'self' https://media.maggieappleton.com; frame-src https://twitter.com https://platform.twitter.com https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://www.figma.com; connect-src 'self' https://syndication.twitter.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Follow-up to the CSP fixes in #77. `global.css` imports Lato via `@import` from `fonts.googleapis.com`, which then references font binaries on `fonts.gstatic.com`. Both hosts need allowlisting — `style-src` for the stylesheet, `font-src` for the `.woff2` files — otherwise Lato silently falls back to the system sans.

## Test plan

- [ ] Verify Lato renders correctly across the site after deploy
- [ ] DevTools console shows no CSP violations for `fonts.googleapis.com` or `fonts.gstatic.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)