### PR TITLE
Improve Cloudinary image quality across egghead and illustrated notes

### DIFF
--- a/src/components/mdx/Alert.astro
+++ b/src/components/mdx/Alert.astro
@@ -28,7 +28,7 @@ const { title } = Astro.props;
 		display: inline-flex;
 		width: 100%;
 		max-width: 780px;
-		padding: var(--space-s) var(--space-xs);
+		padding: var(--space-s) var(--space-xl);
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
@@ -44,10 +44,11 @@ const { title } = Astro.props;
 	}
 
 	:global(.inner-container p) {
+		font-family: var(--font-body);
 		font-size: var(--font-size-base);
 		color: var(--color-gray-800);
 		line-height: var(--leading-loose);
-		max-width: 44ch;
+		max-width: 80ch;
 		margin-bottom: var(--space-m);
 	}
 
@@ -58,9 +59,10 @@ const { title } = Astro.props;
 	}
 
 	.alert-title {
+		font-family: var(--font-sans);
 		color: var(--color-black);
 		text-align: center;
-		font-size: var(--font-size-xl);
+		font-size: var(--font-size-md);
 		font-weight: 600;
 		line-height: var(--leading-tight);
 		margin: 0 auto var(--space-2xs);

--- a/src/components/mdx/ImageLink.astro
+++ b/src/components/mdx/ImageLink.astro
@@ -42,11 +42,9 @@ const { href } = Astro.props;
 	}
 
 	.container {
-		display: inline-block;
+		display: flex;
 		align-items: center;
 		justify-content: center;
 		position: relative;
-		left: 0;
-		top: 0;
 	}
 </style>

--- a/src/content/notes/advancedjs.mdx
+++ b/src/content/notes/advancedjs.mdx
@@ -13,7 +13,7 @@ import ImageLink from "../../components/mdx/ImageLink.astro";
 
 <RemoteImage
 	width="700px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_700/v1580828081/maggieappleton.com/egghead-course-notes/advancedjs-notes/AdvancedJS_1_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1580828081/maggieappleton.com/egghead-course-notes/advancedjs-notes/AdvancedJS_1_2x.png"
 	alt="Advanced JavaScript Fundamentals"
 />
 
@@ -51,25 +51,25 @@ As usual, I drew some notes...
 
 <RemoteImage
 	width="900px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1580828081/maggieappleton.com/egghead-course-notes/advancedjs-notes/AdvancedJS_2_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1580828081/maggieappleton.com/egghead-course-notes/advancedjs-notes/AdvancedJS_2_2x.png"
 	alt="Advanced JavaScript foundations"
 />
 
 <RemoteImage
 	width="900px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1580828082/maggieappleton.com/egghead-course-notes/advancedjs-notes/AdvancedJS_3_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1580828082/maggieappleton.com/egghead-course-notes/advancedjs-notes/AdvancedJS_3_2x.png"
 	alt="Advanced JavaScript foundations"
 />
 
 <RemoteImage
 	width="900px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1580828081/maggieappleton.com/egghead-course-notes/advancedjs-notes/AdvancedJS_4_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1580828081/maggieappleton.com/egghead-course-notes/advancedjs-notes/AdvancedJS_4_2x.png"
 	alt="Advanced JavaScript foundations"
 />
 
 <RemoteImage
 	width="900px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1580828081/maggieappleton.com/egghead-course-notes/advancedjs-notes/AdvancedJS_5.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1580828081/maggieappleton.com/egghead-course-notes/advancedjs-notes/AdvancedJS_5.png"
 	alt="Advanced JavaScript foundations"
 />
 

--- a/src/content/notes/building-gatsby-themes.mdx
+++ b/src/content/notes/building-gatsby-themes.mdx
@@ -29,25 +29,25 @@ They're one of the newer features in [Gatsby.js](https://www.gatsbyjs.org/) – 
 <RemoteImage
 	width="1000px"
 	alt="Building composable gatsby theme title"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_850/v1576769939/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/GatsbyThemes_1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1576769939/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/GatsbyThemes_1.png"
 />
 
 <RemoteImage
 	width="1000px"
 	alt="Gatsby themes let you break a site into reusable chunks of functionality"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1576769938/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/GatsbyThemes_2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1576769938/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/GatsbyThemes_2.png"
 />
 
 <RemoteImage
 	width="1000px"
 	alt="Yarn workspaces are ideal for developing gatsby themes. It lets us have multiple packages in a single repo"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1576769939/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/GatsbyThemes_3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1576769939/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/GatsbyThemes_3.png"
 />
 
 <RemoteImage
 	width="1000px"
 	alt="We're building 3 themes here - marketing, shopify, and blog"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1576769938/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/GatsbyThemes_4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1576769938/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/GatsbyThemes_4.png"
 />
 
 ---
@@ -57,7 +57,7 @@ I also made the course illustration for this one:
 <RemoteImage
 	width="900px"
 	alt="A set of sketches and colour palette tests for the main illustration"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1579731535/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/Twitter.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1579731535/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/Twitter.png"
 />
 
 My <a href="/drawinginvisibles1">process for making these</a> usually sticks to Procreate, Adobe Illustrator, and Photoshop <Footnote idName={1}>You can read more [here](/apps) on what tools and hardware I use</Footnote>, but I experimented with some 3D rendering in Cinema 4D for this one. Certainly sped up the process a bit, though made the final look a little more stiff than usual. Trade offs.
@@ -65,7 +65,7 @@ My <a href="/drawinginvisibles1">process for making these</a> usually sticks to 
 <RemoteImage
 	width="860px"
 	alt="A 3D mockup of a house made of blocks"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1579731531/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/Twitter_2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1579731531/maggieappleton.com/egghead-course-notes/gatsby-themes-notes/Twitter_2.png"
 />
 
 ### Want more illustrated notes on web development?

--- a/src/content/notes/contentful-gatsby.mdx
+++ b/src/content/notes/contentful-gatsby.mdx
@@ -17,7 +17,7 @@ The TLDR here is that combining JavaScript, APIs, and Markup (JAM) makes it easy
 
 <RemoteImage
 	width="300px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_300/v1592855269/maggieappleton.com/egghead-course-notes/gatsby-contentful/thumb_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_300/v1592855269/maggieappleton.com/egghead-course-notes/gatsby-contentful/thumb_2x.png"
 	alt="A stack of jam toast"
 />
 
@@ -38,31 +38,31 @@ Here's some notes I took while working through it...
 <RemoteImage
 	width="700px"
 	alt="Build progressive web apps with contentful and gatsby"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_700/v1592262609/maggieappleton.com/egghead-course-notes/gatsby-contentful/gatsbycontentful1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262609/maggieappleton.com/egghead-course-notes/gatsby-contentful/gatsbycontentful1.png"
 />
 
 <RemoteImage
 	width="950px"
 	alt="The JAM stack is a new way to build web apps for speed and scalability. It uses JavaScript, APIs, and Markup."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1592262609/maggieappleton.com/egghead-course-notes/gatsby-contentful/gatsbycontentful2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262609/maggieappleton.com/egghead-course-notes/gatsby-contentful/gatsbycontentful2.png"
 />
 
 <RemoteImage
 	width="950px"
 	alt="These two work well together - contentful feeds the data into gatsby. You structure all your content inside contentful, which then goes into gatsby through the gatsby-source-contentful plugin."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1592262609/maggieappleton.com/egghead-course-notes/gatsby-contentful/gatsbycontentful3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262609/maggieappleton.com/egghead-course-notes/gatsby-contentful/gatsbycontentful3.png"
 />
 
 <RemoteImage
 	width="950px"
 	alt="We can create new pages for our site inside gatsby-node.js. The gatsby node API gives us a creatPage action"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1592262611/maggieappleton.com/egghead-course-notes/gatsby-contentful/gatsbycontentful4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262611/maggieappleton.com/egghead-course-notes/gatsby-contentful/gatsbycontentful4.png"
 />
 
 <RemoteImage
 	width="1100px"
 	alt="The full gatsby and contentful illustrated note"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_1100/v1592262613/maggieappleton.com/egghead-course-notes/gatsby-contentful/gatsbycontentful_sketchnotes--mini.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262613/maggieappleton.com/egghead-course-notes/gatsby-contentful/gatsbycontentful_sketchnotes--mini.png"
 />
 
 ### Want more illustrated notes on web development?

--- a/src/content/notes/customhooks.mdx
+++ b/src/content/notes/customhooks.mdx
@@ -12,7 +12,7 @@ import ImageLink from "../../components/mdx/ImageLink.astro";
 
 <RemoteImage
 	width="500px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_500/v1591783100/maggieappleton.com/egghead-course-notes/custom-react-hooks/thumb_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_500/v1591783100/maggieappleton.com/egghead-course-notes/custom-react-hooks/thumb_2x.png"
 	alt="Objects hanging off a series of hooks"
 />
 
@@ -47,31 +47,31 @@ Hooks came with a bunch of pre-made options, but also allowed you to remix the d
 
 <RemoteImage
 	width="1000px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1578937254/maggieappleton.com/egghead-course-notes/custom-react-hooks/customhooks-1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1578937254/maggieappleton.com/egghead-course-notes/custom-react-hooks/customhooks-1.png"
 	alt="Making shareable custom react hooks"
 />
 
 <RemoteImage
 	width="1000px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1578937254/maggieappleton.com/egghead-course-notes/custom-react-hooks/customhooks-2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1578937254/maggieappleton.com/egghead-course-notes/custom-react-hooks/customhooks-2.png"
 	alt="Making shareable custom react hooks"
 />
 
 <RemoteImage
 	width="1000px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1578937257/maggieappleton.com/egghead-course-notes/custom-react-hooks/customhooks-3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1578937257/maggieappleton.com/egghead-course-notes/custom-react-hooks/customhooks-3.png"
 	alt="Making shareable custom react hooks"
 />
 
 <RemoteImage
 	width="1000px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1578937255/maggieappleton.com/egghead-course-notes/custom-react-hooks/customhooks-4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1578937255/maggieappleton.com/egghead-course-notes/custom-react-hooks/customhooks-4.png"
 	alt="Making shareable custom react hooks"
 />
 
 <RemoteImage
 	width="1000px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1578937255/maggieappleton.com/egghead-course-notes/custom-react-hooks/customhooks-5.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1578937255/maggieappleton.com/egghead-course-notes/custom-react-hooks/customhooks-5.png"
 	alt="Making shareable custom react hooks"
 />
 

--- a/src/content/notes/cypress.mdx
+++ b/src/content/notes/cypress.mdx
@@ -23,19 +23,19 @@ import ImageLink from "../../components/mdx/ImageLink.astro";
 <RemoteImage
 	width="750px"
 	alt="Cypress.io is a handy tool for end to end testing"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_750/v1592262637/maggieappleton.com/egghead-course-notes/cypress/CyTesting01_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262637/maggieappleton.com/egghead-course-notes/cypress/CyTesting01_2x.png"
 />
 
 <RemoteImage
 	width="860px"
 	alt="It includes all levels of the stack - from the UI to front-end data stores, to XHR, to APIs, to your database. It's able to test all of these at the same time. It runs a virtual browser that clicks through all the things on all the pages"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_860/v1592262636/maggieappleton.com/egghead-course-notes/cypress/CyTesting02_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262636/maggieappleton.com/egghead-course-notes/cypress/CyTesting02_2x.png"
 />
 
 <RemoteImage
 	width="860px"
 	alt="It lets us write custom tests that assert true or false statements on specific parts of our app. It also alerts us if any of those tests fail. The tool uses the chai assertion library which makes it easy to write chains of selectors."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_860/v1592262637/maggieappleton.com/egghead-course-notes/cypress/CyTesting03_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262637/maggieappleton.com/egghead-course-notes/cypress/CyTesting03_2x.png"
 />
 
 ### Want more illustrated notes on web development?

--- a/src/content/notes/es2019.mdx
+++ b/src/content/notes/es2019.mdx
@@ -14,7 +14,7 @@ import ImageLink from "../../components/mdx/ImageLink.astro";
 <RemoteImage
   width="700px"
   alt="New features in JavaScript ES2019"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_700/v1592262624/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-Title.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262624/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-Title.png"
 />
 
 ## A new version of JavaScript has landed!
@@ -38,49 +38,49 @@ I drew up my own notes on the 7 big changes below:
 <RemoteImage
   width="880px"
   alt="Gifts in the latest language update from the TC39 committee"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262624/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-Intro.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262624/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-Intro.png"
 />
 
 <RemoteImage
   width="840px"
   alt="Optional Catch Binding"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262622/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-1-Optional.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262622/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-1-Optional.png"
 />
 
 <RemoteImage
   width="840px"
   alt="Stable array.sort"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262624/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-2-Stable.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262624/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-2-Stable.png"
 />
 
 <RemoteImage
   width="840px"
   alt="Flatten Arrays with flat"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262621/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-3-Flatten.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262621/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-3-Flatten.png"
 />
 
 <RemoteImage
   width="840px"
   alt="Flatten & Map Arrays with flatMap"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262623/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-4-FlatMap.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262623/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-4-FlatMap.png"
 />
 
 <RemoteImage
   width="840px"
   alt="Cut out Whitespace with trimStart & trimEnd"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262619/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-5-Trim.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262619/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-5-Trim.png"
 />
 
 <RemoteImage
   width="840px"
   alt="Descriptions on Symbols"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262622/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-6-Symbol.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262622/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-6-Symbol.png"
 />
 
 <RemoteImage
   width="840px"
   alt="Create Objects from Entries with fromEntries"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262623/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-7-ObjectEntries.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262623/maggieappleton.com/egghead-course-notes/es2019/es2019-sketchnotes-7-ObjectEntries.png"
 />
 
 These notes are all based off Mike Sherov's egghead course on [JavaScript ES2019 in Practice](https://egghead.io/courses/javascript-es2019-in-practice?af=54fd64) which is a good summary of all the new shiny bits, as well as how they apply in IRL dev situations.

--- a/src/content/notes/fruit-comparison.mdx
+++ b/src/content/notes/fruit-comparison.mdx
@@ -18,22 +18,22 @@ growthStage: "evergreen"
 
 <RemoteImage
 	alt="JavaScript's comparison operators give us a way of comparing values"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262865/maggieappleton.com/egghead-course-notes/fruit-comparison/FruitComparison_P1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262865/maggieappleton.com/egghead-course-notes/fruit-comparison/FruitComparison_P1.png"
 />
 
 <RemoteImage
 	alt="Equality comes in loose and strict varieties. You should always use strict equality."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262864/maggieappleton.com/egghead-course-notes/fruit-comparison/FruitComparison_P2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262864/maggieappleton.com/egghead-course-notes/fruit-comparison/FruitComparison_P2.png"
 />
 
 <RemoteImage
 	alt="Inequality follows the same loose and strict rules as equality"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262862/maggieappleton.com/egghead-course-notes/fruit-comparison/FruitComparison_P3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262862/maggieappleton.com/egghead-course-notes/fruit-comparison/FruitComparison_P3.png"
 />
 
 <RemoteImage
 	alt="Relational equality let's us check which value is greater"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262863/maggieappleton.com/egghead-course-notes/fruit-comparison/FruitComparison_P4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262863/maggieappleton.com/egghead-course-notes/fruit-comparison/FruitComparison_P4.png"
 />
 
 ### Want more illustrated notes on web development?

--- a/src/content/notes/git-mistakes.mdx
+++ b/src/content/notes/git-mistakes.mdx
@@ -12,7 +12,7 @@ import ImageLink from "../../components/mdx/ImageLink.astro";
 
 <RemoteImage
   width="750px"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_980/v1576769959/maggieappleton.com/git-mistakes/FixGitMistakes_4.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1576769959/maggieappleton.com/git-mistakes/FixGitMistakes_4.png"
   alt="Fixing common git mistakes"
 />
 
@@ -29,43 +29,43 @@ Illustrated notes I made while working through [Chris Achard](https://chrisachar
 
 <RemoteImage
   width="1050px"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_980/v1590015687/maggieappleton.com/git-mistakes/FixGitMistakes_3.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1590015687/maggieappleton.com/git-mistakes/FixGitMistakes_3.png"
   alt="Fixing common git mistakes"
 />
 
 <RemoteImage
   width="900px"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_980/v1590015790/maggieappleton.com/git-mistakes/FixGitMistakes_1.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1590015790/maggieappleton.com/git-mistakes/FixGitMistakes_1.png"
   alt="Fixing common git mistakes"
 />
 
 <RemoteImage
   width="900px"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_980/v1590015637/maggieappleton.com/git-mistakes/Artboard_2.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1590015637/maggieappleton.com/git-mistakes/Artboard_2.png"
   alt="Fixing common git mistakes"
 />
 
 <RemoteImage
   width="900px"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_980/v1590015638/maggieappleton.com/git-mistakes/Artboard_3.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1590015638/maggieappleton.com/git-mistakes/Artboard_3.png"
   alt="Fixing common git mistakes"
 />
 
 <RemoteImage
   width="900px"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_960/v1590015643/maggieappleton.com/git-mistakes/Artboard_4.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1590015643/maggieappleton.com/git-mistakes/Artboard_4.png"
   alt="Fixing common git mistakes"
 />
 
 <RemoteImage
   width="950px"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_980/v1590015844/maggieappleton.com/git-mistakes/FixGitMistakes_2.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1590015844/maggieappleton.com/git-mistakes/FixGitMistakes_2.png"
   alt="Fixing common git mistakes"
 />
 
 <RemoteImage
   width="900px"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_980/v1590015640/maggieappleton.com/git-mistakes/Artboard_4_copy.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1590015640/maggieappleton.com/git-mistakes/Artboard_4_copy.png"
   alt="Fixing common git mistakes"
 />
 

--- a/src/content/notes/graphql.mdx
+++ b/src/content/notes/graphql.mdx
@@ -17,7 +17,7 @@ import GridColumns from "../../components/mdx/GridColumns.astro";
 <RemoteImage
   width="400px"
   alt="Small GraphQL schema dictionary illustration"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_300/v15928510008/maggieappleton.com/egghead-course-notes/graphql/thumb_2x.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_300/v15928510008/maggieappleton.com/egghead-course-notes/graphql/thumb_2x.png"
 />
 
 If you're lucky enough to already grok GraphQL, you'll know the _QL_ stands for _Query Language_ – aka. the language we talk to our GraphQL API in.
@@ -41,31 +41,31 @@ Anyways, as usual I drew some things:
 <RemoteImage
   width="750px"
   alt="How to talk to a GraphQL API. We can use the graphQL playground to send queries to a GraphQL endpoint. The playground lets us explore our data before making any requests"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_750/v1592262603/maggieappleton.com/egghead-course-notes/graphql/graphql1.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262603/maggieappleton.com/egghead-course-notes/graphql/graphql1.png"
 />
 
 <RemoteImage
   width="1100px"
   alt="A query is a request for data. We open it with the query keyword and a set of curly braces. Curly braces wrap around a selection and say go look inside this object. Blank spaces at the end of a line are fields that say I want his data please. We can also add the 'total' and 'all' keywords in front of any list of objects."
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_1100/v1592262605/maggieappleton.com/egghead-course-notes/graphql/graphql4.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262605/maggieappleton.com/egghead-course-notes/graphql/graphql4.png"
 />
 
 <RemoteImage
   width="800px"
   alt="Inside the playground, ctrl + space is a magic combination that reveals all the available fields of a query"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_800/v1592262603/maggieappleton.com/egghead-course-notes/graphql/graphql2.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262603/maggieappleton.com/egghead-course-notes/graphql/graphql2.png"
 />
 
 <RemoteImage
   width="1100px"
   alt="We can filter our data by adding arguments to our queries. This means we only get the data we want. We can also use mutations to change the data. This includes creating, updating, and deleting data."
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_1100/v1592262604/maggieappleton.com/egghead-course-notes/graphql/graphql3.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262604/maggieappleton.com/egghead-course-notes/graphql/graphql3.png"
 />
 
 <RemoteImage
   width="1100px"
   alt="The full GraphQL query language illustrated note"
-  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262601/maggieappleton.com/egghead-course-notes/graphql/graphql_sketchnotes--mini.png"
+  src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262601/maggieappleton.com/egghead-course-notes/graphql/graphql_sketchnotes--mini.png"
 />
 
 <Center>

--- a/src/content/notes/immer.mdx
+++ b/src/content/notes/immer.mdx
@@ -50,25 +50,25 @@ Michel walks us through building a gifting app with React & Immer that seamlessl
 <RemoteImage
 	width="1100px"
 	alt="Immer is a small JS library that makes working with immutable state easy and enjoyable. It's like a small assistant that helps you make copies and edits to documents."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262596/maggieappleton.com/egghead-course-notes/immer/immer-1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262596/maggieappleton.com/egghead-course-notes/immer/immer-1.png"
 />
 
 <RemoteImage
 	width="1100px"
 	alt="Immer's produce function does all the work - it takes a state object and runs a draft function telling the state how it should change."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262597/maggieappleton.com/egghead-course-notes/immer/immer-2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262597/maggieappleton.com/egghead-course-notes/immer/immer-2.png"
 />
 
 <RemoteImage
 	width="1100px"
 	alt="The product function supports currying - which is when we nest functions inside others to make our code composable"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262597/maggieappleton.com/egghead-course-notes/immer/immer-3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262597/maggieappleton.com/egghead-course-notes/immer/immer-3.png"
 />
 
 <RemoteImage
 	width="1100px"
 	alt="We can easily use immer with other libraries like React and write callback functions using immer's produce function"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262596/maggieappleton.com/egghead-course-notes/immer/immer-4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262596/maggieappleton.com/egghead-course-notes/immer/immer-4.png"
 />
 
 <br />

--- a/src/content/notes/react-vdom.mdx
+++ b/src/content/notes/react-vdom.mdx
@@ -30,36 +30,30 @@ The idea of the virtual DOM system helped clarify a few things for me. Primarily
 
 ## Disclaimer
 
-The React team no longer uses the **"Virtual DOM"** as a mental model for how React works under the hood.
+The React team no longer uses the **"Virtual DOM"** as a mental model for how React works under the hood. Instead Dan wrote up a nice long explanation on [React as a UI Runtime](https://overreacted.io/react-as-a-ui-runtime/) which clarifies the details how React updates the UI.
 
-<TweetEmbed tweetId="1066328666341294080" />
-
-Instead Dan wrote up a nice long explanation on <a href="https://overreacted.io/react-as-a-ui-runtime/">React as a UI Runtime</a> which clarifies the details how React updates the UI.
-
-They still have a section of the docs about the [Virtual DOM](https://reactjs.org/docs/faq-internals.html), but it's not an essential piece of the React ecosystem to learn about.
-
-The below explanation will still help you understand the basic concept that React figures out what needs to change on the DOM before changing it, but go to other sources if you want a more in-depth explanation.
+They still have a section of the docs about the [Virtual DOM](https://reactjs.org/docs/faq-internals.html), but it's not an essential piece of the React ecosystem to learn about. The below explanation will still help you understand the basic concept that React figures out what needs to change on the DOM before changing it, but go to other sources if you want a more in-depth explanation.
 
 </Alert>
 
 <RemoteImage
 	alt="One of the reasons React is so darn fast at updating changes  is that it uses a virtual DOM"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262854/maggieappleton.com/egghead-course-notes/react-vdom/ReactVDom_1_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262854/maggieappleton.com/egghead-course-notes/react-vdom/ReactVDom_1_2x.png"
 />
 
 <RemoteImage
 	alt="All the code we write in React only interacts with this virtual DOM"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262852/maggieappleton.com/egghead-course-notes/react-vdom/ReactVDom_2_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262852/maggieappleton.com/egghead-course-notes/react-vdom/ReactVDom_2_2x.png"
 />
 
 <RemoteImage
 	alt="This is helpful because passing the actual DOM lots of changes is slow"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262852/maggieappleton.com/egghead-course-notes/react-vdom/ReactVDom_3_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262852/maggieappleton.com/egghead-course-notes/react-vdom/ReactVDom_3_2x.png"
 />
 
 <RemoteImage
 	alt="React's DOM runs a diffing algorithm"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262854/maggieappleton.com/egghead-course-notes/react-vdom/ReactVDom_4_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262854/maggieappleton.com/egghead-course-notes/react-vdom/ReactVDom_4_2x.png"
 />
 
 ### Want more illustrated notes on web development?

--- a/src/content/notes/react360.mdx
+++ b/src/content/notes/react360.mdx
@@ -34,31 +34,31 @@ Here's all my illustrated notes on the material.
 <RemoteImage
 	width="750px"
 	alt="VR apps with React 360"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_750/v1592262587/maggieappleton.com/egghead-course-notes/react360/react360_p1_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262587/maggieappleton.com/egghead-course-notes/react360/react360_p1_2x.png"
 />
 
 <RemoteImage
 	width="900px"
 	alt="Let's us build 3D and VR apps on the web - without needing to learn crazy complex tools like WebGL. Instead we can just use React"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262588/maggieappleton.com/egghead-course-notes/react360/react360_p2_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262588/maggieappleton.com/egghead-course-notes/react360/react360_p2_2x.png"
 />
 
 <RemoteImage
 	width="1000px"
 	alt="Uses flexbox for layouts. On the web it flexes across rows by default. But in VR it flexes downwards in a stacked columns. To add CSS styles to our views, we make a special React 360 stylesheet and then we pass them to the style tag"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_1000/v1592262589/maggieappleton.com/egghead-course-notes/react360/react360_p3_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262589/maggieappleton.com/egghead-course-notes/react360/react360_p3_2x.png"
 />
 
 <RemoteImage
 	width="800px"
 	alt="Add 3D models to your components with the Entity tag. We can apply CSS transforms to these"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_800/v1592262587/maggieappleton.com/egghead-course-notes/react360/react360_p4_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262587/maggieappleton.com/egghead-course-notes/react360/react360_p4_2x.png"
 />
 
 <RemoteImage
 	width="1100px"
 	alt="The full React 360 illustrated note"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_1000/v1592262590/maggieappleton.com/egghead-course-notes/react360/react360_full_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262590/maggieappleton.com/egghead-course-notes/react360/react360_full_2x.png"
 />
 
 ### Want more illustrated notes on web development?

--- a/src/content/notes/reactsuspense.mdx
+++ b/src/content/notes/reactsuspense.mdx
@@ -16,22 +16,22 @@ import ImageLink from "../../components/mdx/ImageLink.astro";
 <RemoteImage
 	width="800px"
 	alt="Wtf is React supense?"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_750/v1592262756/maggieappleton.com/egghead-course-notes/reactsuspense/WftReactSuspense_1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262756/maggieappleton.com/egghead-course-notes/reactsuspense/WftReactSuspense_1.png"
 />
 
 <RemoteImage
 	alt="Allows us to suspend rendering parts of our app until a particular condition is met, such as waiting until our data load. This keeps our interface interactive."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262756/maggieappleton.com/egghead-course-notes/reactsuspense/WftReactSuspense_2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262756/maggieappleton.com/egghead-course-notes/reactsuspense/WftReactSuspense_2.png"
 />
 
 <RemoteImage
 	alt="This allows us to prioritize the order that elements render in, based on those conditions. From high priority to low priority."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262754/maggieappleton.com/egghead-course-notes/reactsuspense/WftReactSuspense_4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262754/maggieappleton.com/egghead-course-notes/reactsuspense/WftReactSuspense_4.png"
 />
 
 <RemoteImage
 	alt="We create a suspense boundary around our components, and declare a fallback element to display while the data is loading."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262755/maggieappleton.com/egghead-course-notes/reactsuspense/WftReactSuspense_3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262755/maggieappleton.com/egghead-course-notes/reactsuspense/WftReactSuspense_3.png"
 />
 
 This is a pretty lightweight intro, but you get the gist of it. CSS-Tricks has a nice in-depth write up on [React Suspense in Practice](https://css-tricks.com/react-suspense-in-practice/)

--- a/src/content/notes/spread.mdx
+++ b/src/content/notes/spread.mdx
@@ -17,7 +17,7 @@ Mystery solved...
 
 <RemoteImage
 	alt="JavaScript's spread operator copies the content of one array, and dumps them out into another"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262848/maggieappleton.com/egghead-course-notes/Spread.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_2200/v1592262848/maggieappleton.com/egghead-course-notes/Spread.png"
 />
 
 ### Want more illustrated notes on web development?

--- a/src/content/notes/visual-aws.mdx
+++ b/src/content/notes/visual-aws.mdx
@@ -34,7 +34,7 @@ Here's Tomasz thinking very hard about API Gateways and Lambda Functions
 	framed
 	width="1200px"
 	alt="A screenshot of the zoom video call where we're drawing out rough diagrams"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_1200/v1592314229/maggieappleton.com/notes/visual-aws/workshop-screen.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592314229/maggieappleton.com/notes/visual-aws/workshop-screen.png"
 />
 
 ## The Process
@@ -46,7 +46,7 @@ and arrows and labels like this:
 	framed
 	width="950px"
 	alt="A sketchy diagram of the elements inside an AWS data centre"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1592317154/maggieappleton.com/notes/visual-aws/aws-cdk-post-10.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317154/maggieappleton.com/notes/visual-aws/aws-cdk-post-10.png"
 />
 
 It's all you really need to establish the basics. Nouns (things) are boxes,
@@ -60,7 +60,7 @@ scene:
 	framed
 	width="950px"
 	alt="A blue pencil sketch of the elements inside an AWS data centre and how they connect to a React app"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1592317154/maggieappleton.com/notes/visual-aws/aws-cdk-post-11.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317154/maggieappleton.com/notes/visual-aws/aws-cdk-post-11.png"
 />
 
 I ran the sketch by Tomasz to make sure all the technical details were
@@ -69,7 +69,7 @@ correct. Then did a final linework pass over the top to neaten everything up:
 <RemoteImage
 	width="950px"
 	alt="A refined ink ilustration showing the relationship between a React app, AWS API gateway, and lambda functions"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317154/maggieappleton.com/notes/visual-aws/aws-cdk-post-12.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317154/maggieappleton.com/notes/visual-aws/aws-cdk-post-12.png"
 />
 
 We ended up with five of these illustrations that cover all the main concepts of
@@ -87,14 +87,14 @@ the course
 	framed
 	width="720px"
 	alt="Rough sketches of the location of AWS data centres"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317152/maggieappleton.com/notes/visual-aws/aws-cdk-post-7.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317152/maggieappleton.com/notes/visual-aws/aws-cdk-post-7.png"
 />
 
 <RemoteImage
 	framed
 	width="720px"
 	alt="Blue pencil sketches of the location of AWS data centres"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317153/maggieappleton.com/notes/visual-aws/aws-cdk-post-8.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317153/maggieappleton.com/notes/visual-aws/aws-cdk-post-8.png"
 />
 
 </GridColumns>
@@ -102,7 +102,7 @@ the course
 <RemoteImage
 	width="950px"
 	alt="Final illustration of the location of AWS data centres"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317155/maggieappleton.com/notes/visual-aws/aws-cdk-post-9.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317155/maggieappleton.com/notes/visual-aws/aws-cdk-post-9.png"
 />
 
 ---
@@ -113,13 +113,13 @@ the course
 	framed
 	width="720px"
 	alt=""
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317155/maggieappleton.com/notes/visual-aws/aws-cdk-post-13.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317155/maggieappleton.com/notes/visual-aws/aws-cdk-post-13.png"
 />
 
 <RemoteImage
 	framed
 	width="720px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317156/maggieappleton.com/notes/visual-aws/aws-cdk-post-14.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317156/maggieappleton.com/notes/visual-aws/aws-cdk-post-14.png"
 />
 
 </GridColumns>
@@ -127,13 +127,13 @@ the course
 <RemoteImage
 	alt=""
 	width="950px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1592317155/maggieappleton.com/notes/visual-aws/aws-cdk-post-15.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317155/maggieappleton.com/notes/visual-aws/aws-cdk-post-15.png"
 />
 
 <RemoteImage
 	alt=""
 	width="950px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_950/v1592317157/maggieappleton.com/notes/visual-aws/aws-cdk-post-16.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317157/maggieappleton.com/notes/visual-aws/aws-cdk-post-16.png"
 />
 
 ---
@@ -144,14 +144,14 @@ the course
 	framed
 	alt=""
 	width="720px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317152/maggieappleton.com/notes/visual-aws/aws-cdk-post-4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317152/maggieappleton.com/notes/visual-aws/aws-cdk-post-4.png"
 />
 
 <RemoteImage
 	framed
 	alt=""
 	width="720px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317151/maggieappleton.com/notes/visual-aws/aws-cdk-post-5.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317151/maggieappleton.com/notes/visual-aws/aws-cdk-post-5.png"
 />
 
 </GridColumns>
@@ -159,7 +159,7 @@ the course
 <RemoteImage
 	alt=""
 	width="950px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317153/maggieappleton.com/notes/visual-aws/aws-cdk-post-6.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317153/maggieappleton.com/notes/visual-aws/aws-cdk-post-6.png"
 />
 
 ---
@@ -170,14 +170,14 @@ the course
 	framed
 	alt=""
 	width="720px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317151/maggieappleton.com/notes/visual-aws/aws-cdk-post-1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317151/maggieappleton.com/notes/visual-aws/aws-cdk-post-1.png"
 />
 
 <RemoteImage
 	framed
 	alt=""
 	width="720px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317152/maggieappleton.com/notes/visual-aws/aws-cdk-post-2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317152/maggieappleton.com/notes/visual-aws/aws-cdk-post-2.png"
 />
 
 </GridColumns>
@@ -185,7 +185,7 @@ the course
 <RemoteImage
 	alt=""
 	width="950px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592317152/maggieappleton.com/notes/visual-aws/aws-cdk-post-3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592317152/maggieappleton.com/notes/visual-aws/aws-cdk-post-3.png"
 />
 
 If you're just here for all the gritty details of AWS you might want to check out the course itself. If you're here for the visual process, I popped a few more thoughts below..

--- a/src/content/notes/vuerouter.mdx
+++ b/src/content/notes/vuerouter.mdx
@@ -15,7 +15,7 @@ import ImageLink from "../../components/mdx/ImageLink.astro";
 <RemoteImage
 	width="500px"
 	alt="A box with green vue roads coming out of it"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262763/maggieappleton.com/egghead-course-notes/vuerouter/thumb_2x.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262763/maggieappleton.com/egghead-course-notes/vuerouter/thumb_2x.png"
 />
 
 I got to see inside the Vue-machine a little while working through [Laurie Barth](https://twitter.com/laurieontech)'s [egghead course](https://egghead.io/courses/a-journey-with-vue-router) on how to set up routes between Vue pages and components.
@@ -25,25 +25,25 @@ I made a few illustrated notes on the main concepts
 <RemoteImage
 	width="1050px"
 	alt="Journey with Vue Router"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262764/maggieappleton.com/egghead-course-notes/vuerouter/VueRouter_1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262764/maggieappleton.com/egghead-course-notes/vuerouter/VueRouter_1.png"
 />
 
 <RemoteImage
 	width="1050px"
 	alt="To setup, install and import vue router, create an empty array of routes, and pass that array into a new router function"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262762/maggieappleton.com/egghead-course-notes/vuerouter/VueRouter_2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262762/maggieappleton.com/egghead-course-notes/vuerouter/VueRouter_2.png"
 />
 
 <RemoteImage
 	width="1050px"
 	alt="When making new routes, each one needs a path and a component. We can also pass parameters to our routes"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262765/maggieappleton.com/egghead-course-notes/vuerouter/VueRouter_3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262765/maggieappleton.com/egghead-course-notes/vuerouter/VueRouter_3.png"
 />
 
 <RemoteImage
 	width="1050px"
 	alt="The wild card path acts as a cacthall for unknown routes"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1592262764/maggieappleton.com/egghead-course-notes/vuerouter/VueRouter_4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262764/maggieappleton.com/egghead-course-notes/vuerouter/VueRouter_4.png"
 />
 
 <br />

--- a/src/content/notes/vuesocket.mdx
+++ b/src/content/notes/vuesocket.mdx
@@ -35,25 +35,25 @@ I obviously still haven't a clue what goes on inside that dark little portal. Th
 <RemoteImage
 	width="700px"
 	alt="Vue and socket.io for real-time communication"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_700/v1592262571/maggieappleton.com/egghead-course-notes/vuesocket/vuesocket1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262571/maggieappleton.com/egghead-course-notes/vuesocket/vuesocket1.png"
 />
 
 <RemoteImage
 	width="900px"
 	alt="Socket.io gives us bidirectional communication between two clients"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262575/maggieappleton.com/egghead-course-notes/vuesocket/vuesocket2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262575/maggieappleton.com/egghead-course-notes/vuesocket/vuesocket2.png"
 />
 
 <RemoteImage
 	width="800px"
 	alt="The emit method lets us send and recieve any knd of event. We can target specific users or a group of users"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_800/v1592262574/maggieappleton.com/egghead-course-notes/vuesocket/vuesocket3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262574/maggieappleton.com/egghead-course-notes/vuesocket/vuesocket3.png"
 />
 
 <RemoteImage
 	width="1100px"
 	alt="The full vue and socket sketchnote"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_1100/v1592262568/maggieappleton.com/egghead-course-notes/vuesocket/vuesocket_sketchnotes--mini.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262568/maggieappleton.com/egghead-course-notes/vuesocket/vuesocket_sketchnotes--mini.png"
 />
 
 ### Want more illustrated notes on web development?

--- a/src/content/notes/websecurity.mdx
+++ b/src/content/notes/websecurity.mdx
@@ -39,7 +39,7 @@ Here's my illustrated notes from Mike's course that should give you a big pictur
 <RemoteImage
 	width="850px"
 	alt="Web security essentials - Let's look at three common attacks"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_780/v1592262535/maggieappleton.com/egghead-course-notes/websecurity/web-security-1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262535/maggieappleton.com/egghead-course-notes/websecurity/web-security-1.png"
 />
 
 Turns out there's a small set of fairly well-known and easy to defend attacks that we can protect ourselves from:
@@ -53,37 +53,37 @@ Shielding yourself from these three is a great starting point. It's at least eno
 <RemoteImage
 	width="1000px"
 	alt="First, man in the middle is a piece of software that intercepts data between a client and a server"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262537/maggieappleton.com/egghead-course-notes/websecurity/web-security-2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262537/maggieappleton.com/egghead-course-notes/websecurity/web-security-2.png"
 />
 
 <RemoteImage
 	width="950px"
 	alt="If this connection is over HTTP all your data packets are readable cleartext. Anyone on the network can use a packet sniffer to see your data. Instead we use HTTPS to encrypt packets."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262538/maggieappleton.com/egghead-course-notes/websecurity/web-security-6.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262538/maggieappleton.com/egghead-course-notes/websecurity/web-security-6.png"
 />
 
 <RemoteImage
 	width="1000px"
 	alt="How to protect yourself. Use HSTS headers. Require HTTPS everywhere. Redirect HTTP to HTTPS"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262533/maggieappleton.com/egghead-course-notes/websecurity/web-security-7.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262533/maggieappleton.com/egghead-course-notes/websecurity/web-security-7.png"
 />
 
 <RemoteImage
 	width="1000px"
 	alt="Cross-site request forgery is an attack that tricks the user into visiting a malicious site while they're already logged into a trusted site"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262538/maggieappleton.com/egghead-course-notes/websecurity/web-security-3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262538/maggieappleton.com/egghead-course-notes/websecurity/web-security-3.png"
 />
 
 <RemoteImage
 	width="1000px"
 	alt="This is possible because browsers send cookies between sites by default. How to protect yourself. Cookies come with a 'sameSite' property that prevents them from being passed between sites. Set it to 'lax' or 'strict'"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262536/maggieappleton.com/egghead-course-notes/websecurity/web-security-4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262536/maggieappleton.com/egghead-course-notes/websecurity/web-security-4.png"
 />
 
 <RemoteImage
 	width="1000px"
 	alt="Cross-site scripting is an attack that injects malicious code into a trusted site. This can happen is the site allows user input to appear on the page without validating or encoding it. Protect yourself with a content security policy which manages which types of resources are allowed to load and where"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262536/maggieappleton.com/egghead-course-notes/websecurity/web-security-5.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262536/maggieappleton.com/egghead-course-notes/websecurity/web-security-5.png"
 />
 
 Keeping out this trio of attacks will go a long way.
@@ -96,7 +96,7 @@ Better safe than sorry. Especially when sorry means you end up on the front page
 
 <RemoteImage
 	alt="The fully illustrated notes on web security essentials"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262538/maggieappleton.com/egghead-course-notes/websecurity/web-security-final--small.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262538/maggieappleton.com/egghead-course-notes/websecurity/web-security-final--small.png"
 />
 
 ---

--- a/src/content/notes/wtf-rust.mdx
+++ b/src/content/notes/wtf-rust.mdx
@@ -17,7 +17,7 @@ import ImageLink from "../../components/mdx/ImageLink.astro";
 	framed
 	alt="Chart showing rust at the top of the rankings for most loved languages with 83.5%"
 	width="800px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_750/v1592262509/maggieappleton.com/egghead-course-notes/wtf-rust/stackoverflow.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262509/maggieappleton.com/egghead-course-notes/wtf-rust/stackoverflow.png"
 />
 
 So, what's this Rust thing and why is everyone enamoured?  
@@ -25,20 +25,20 @@ Let's explore...
 
 <RemoteImage
 	width="800px"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_800/v1592262461/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_1.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262461/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_1.png"
 	alt="An Introduction to Rust"
 />
 
 <RemoteImage
 	width="900px"
 	alt="Rust is a programming language mainly used to build 'system software.' Which means any software that acts as a platform for other software to run on top of it. iOS, linux, and windows are all system software. Rust is also becoming popular for making web apps. We can compile rust files into web assembly, which lets us run them in the browser."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_960/v1592262462/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262462/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_2.png"
 />
 
 <RemoteImage
 	width="900px"
 	alt="The power of rust is that it balances speed and safety. Safety here means memory safety. Mishandling how we store data on physical microchips can lead to bugs and security flaws. High-level languages are abstract and safer. Low-level languages work directly with memory, making them dangerous but fast. Rust lives in the happy middle ground"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_960/v1592262462/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262462/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_4.png"
 />
 
 This happy balance Rust manages to strike – between speed, control over memory, and human-friendliness is what makes it so popular.
@@ -56,19 +56,19 @@ And no one wants to join a bunch of judgey gatekeepers.
 <RemoteImage
 	width="900px"
 	alt="The rust install package comes with 'rustc' - the compiler, 'cargo' - the package manager, and 'rustup' - the toolchain"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_960/v1592262461/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262461/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_3.png"
 />
 
 <RemoteImage
 	width="900px"
 	alt="Rust is statically typed. This means the data type of every variable must be known at compile time. You can declare data types or let rust make an educated guess. Rust's compiler is strict. It won't let you mix data types."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_960/v1592262462/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_5.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262462/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_5.png"
 />
 
 <RemoteImage
 	width="900px"
 	alt="Rust is obsessed with ownership. Every value belongs to a variable. Values are like pet hamsters, they need an owner. If LeBron owns this hamster, then we assign LeBron to Shaq, ownership move to Shaq. LeBron no longer owns the hamster."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_960/v1592262465/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_6.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262465/maggieappleton.com/egghead-course-notes/wtf-rust/WTFRust_6.png"
 />
 
 I've just done a sweeping and completely incomplete overview of Rust here. But it's enough to point you in the right direction. There's plenty more to explore.

--- a/src/content/notes/xstate.mdx
+++ b/src/content/notes/xstate.mdx
@@ -19,7 +19,7 @@ There's also a handy [visualiser tool](https://xstate.js.org/viz/) that synchron
 <RemoteImage
 	framed
 	alt="Screenshot of the xState visualizer"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_920/v1592930602/maggieappleton.com/egghead-course-notes/xstate/Screenshot_2020-06-23_at_17.41.45.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592930602/maggieappleton.com/egghead-course-notes/xstate/Screenshot_2020-06-23_at_17.41.45.png"
 />
 
 <br />
@@ -31,25 +31,25 @@ Here's a little more illustrated detail on how this works:
 <RemoteImage
 	width="900px"
 	alt="Xstate is a tool that helps you plan out all the possible states in a JavaScript app"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_750/v1592931672/maggieappleton.com/egghead-course-notes/xstate/xState_5.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592931672/maggieappleton.com/egghead-course-notes/xstate/xState_5.png"
 />
 
 <RemoteImage
 	width="800px"
 	alt="There's a handy interactive visualizer tool at xstate.js.org/viz"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_860/v1592262779/maggieappleton.com/egghead-course-notes/xstate/xState_2.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262779/maggieappleton.com/egghead-course-notes/xstate/xState_2.png"
 />
 
 <RemoteImage
 	width="900px"
 	alt="A sequence of light bulbs swapping states between unlit, lit, dim, and broken."
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262781/maggieappleton.com/egghead-course-notes/xstate/xState_3.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262781/maggieappleton.com/egghead-course-notes/xstate/xState_3.png"
 />
 
 <RemoteImage
 	width="900px"
 	alt="We can add extra options onto our states such as actions, services, guards, and activities"
-	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,w_900/v1592262777/maggieappleton.com/egghead-course-notes/xstate/xState_4.png"
+	src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262777/maggieappleton.com/egghead-course-notes/xstate/xState_4.png"
 />
 
 If you're keen to learn more xState there's two courses up on egghead that cover all the basics:

--- a/src/links.json
+++ b/src/links.json
@@ -3630,7 +3630,7 @@
     ],
     "slug": "zero-alignment",
     "growthStage": "evergreen",
-    "description": "Why we need collaborative AI engineering",
+    "description": "Why we need collaborative AI engineering and a tour of Ace: the multiplayer coding workspace",
     "outboundLinks": [],
     "inboundLinks": []
   }

--- a/src/plugins/remark-wiki-link.js
+++ b/src/plugins/remark-wiki-link.js
@@ -23,15 +23,16 @@ export function remarkWikiLink() {
 					});
 				}
 
-				// Find the matching post in linkMaps
+				// Normalize curly quotes added by remark-smartypants before matching
+				const normalizedText = linkText.replace(/[‘’]/g, "'").replace(/[“”]/g, '"');
 				const matchedPost = linkMaps.find((post) =>
-					post.ids.some((id) => id.toLowerCase() === linkText.toLowerCase())
+					post.ids.some((id) => id.toLowerCase() === normalizedText.toLowerCase())
 				);
 
 				if (matchedPost) {
 					// Create the InternalTooltipLink component
 					children.push({
-						type: "mdxJsxFlowElement",
+						type: "mdxJsxTextElement",
 						name: "InternalTooltipLink",
 						attributes: [
 							{


### PR DESCRIPTION
## Summary

- Upgrades Cloudinary delivery params from `q_auto:good,w_1200` to `q_auto:best,w_1800` across all egghead course note pages and illustrated notes (react-vdom, fruit-comparison, spread, etc.)
- Adds missing `f_auto,q_auto:best` quality params to images that had none, and bumps their width to `w_1800` for retina sharpness
- Also includes Alert component style tweaks (padding, font, max-width) and ImageLink layout fix from earlier work on this branch

## Test plan

- [ ] Spot-check a few egghead note pages (e.g. /xstate, /websecurity, /react-vdom) and verify images are visibly sharper, especially on retina displays
- [ ] Confirm no broken images (all URLs are valid Cloudinary transforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)