### PR TITLE
remove dead egghead store section from graphql note

### DIFF
--- a/src/content/notes/graphql.mdx
+++ b/src/content/notes/graphql.mdx
@@ -68,30 +68,6 @@ Anyways, as usual I drew some things:
   src="https://res.cloudinary.com/dg3gyk0gu/image/upload/c_scale,f_auto,q_auto:best,w_1800/v1592262601/maggieappleton.com/egghead-course-notes/graphql/graphql_sketchnotes--mini.png"
 />
 
-<Center>
-
-## Bonus Poster
-
-</Center>
-
-Twitter kept bugging me to make prints out of these illustrated notes, so this one is now purchaseable as a real life object on the [egghead store](https://store.egghead.io/).
-
-There's framed versions and unframed, depending on how fancy you feel. You can [buy one here](https://store.egghead.io/product/poster-graphql-query-language) if you so desire.
-
-<GridColumns gridGap="1em">
-
-<RemoteImage
-  alt="a framed graphql illustrated print"
-  src="https://store.egghead.io/static/ab87b8544078b8d5049501abf8b2eac7/e9055/thumb-graphql-query-language-by-eve-porcello_2x_dd5b8572-fca2-4c36-9e4e-d4bfc00a35fb.png"
-/>
-
-<RemoteImage
-  alt="a close-up image of one section of the print"
-  src="https://store.egghead.io/static/91261ff8c8395dbc141635030e138734/fd7f1/perspective_2x_420b9d42-49db-41ac-8aee-1b8fa25c56eb.png"
-/>
-
-</GridColumns>
-
 ### Want more illustrated notes on web development?
 
 Take a look at [[A Fresh Serving of JavaScript ES2019]], [[The JAMStack, Gatsby & Contentful]] or [[Essential Web Security Tactics]]


### PR DESCRIPTION
The two broken images on \`/graphql\` are from \`store.egghead.io\`, which has been shut down — both the product page and the static asset URLs return 404. This removes the \"Bonus Poster\" section since everything in it (the store link, the \"buy one here\" link, and the two preview images) points at dead URLs.

Closes the page-feedback report on \`/graphql\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)