### PR TITLE
Fix MysteriousVoid full-width dark section

### DIFF
--- a/src/components/layouts/PageWrapper.astro
+++ b/src/components/layouts/PageWrapper.astro
@@ -13,7 +13,7 @@ const { class: className } = Astro.props;
 <style>
 	main {
 		max-width: 1420px;
-		margin: var(--space-l) auto var(--space-128);
+		margin: var(--space-l) auto var(--space-3xl);
 		padding: 0 var(--space-l);
 	}
 	/* 14" and 13" MacBook Pro screens (1280–1512px logical width) need extra side breathing room */

--- a/src/components/layouts/VersionDropdown.astro
+++ b/src/components/layouts/VersionDropdown.astro
@@ -143,7 +143,7 @@ const getVersionUrl = (version: VersionedContent) => {
 		cursor: pointer;
 		display: inline-flex;
 		align-items: center;
-		gap: var(--space-8);
+		gap: var(--space-2xs);
 		font-family: var(--font-sans);
 		font-size: var(--font-size-xs);
 		color: var(--color-gray-600);
@@ -173,7 +173,7 @@ const getVersionUrl = (version: VersionedContent) => {
 		border: 1px solid var(--color-tinted-cream);
 		border-radius: var(--border-radius-base);
 		box-shadow: var(--box-shadow-lg);
-		padding: var(--space-16);
+		padding: var(--space-xs);
 		min-width: 320px;
 		z-index: 1000;
 		opacity: 0;

--- a/src/components/mdx/Accordion.astro
+++ b/src/components/mdx/Accordion.astro
@@ -37,12 +37,12 @@ const { header } = Astro.props;
 		justify-content: space-between;
 		align-items: center;
 		flex-wrap: wrap;
-		gap: var(--space-8);
+		gap: var(--space-2xs);
 		border-radius: 6px;
 		background: #f0f9f8;
 		border: 1px solid #ade3e3;
 		border-left: 6px solid var(--color-sea-blue);
-		padding: var(--space-16) var(--space-24);
+		padding: var(--space-xs) var(--space-s);
 		color: var(--color-dark-sea-blue);
 		transition: all 0.3s ease;
 	}
@@ -65,7 +65,7 @@ const { header } = Astro.props;
 		display: flex;
 		flex-direction: row;
 		align-items: center;
-		gap: var(--space-8);
+		gap: var(--space-2xs);
 		text-align: left;
 		font-size: calc(var(--font-size-base) / 1.25);
 	}
@@ -85,7 +85,7 @@ const { header } = Astro.props;
 		display: flex;
 		flex-direction: row;
 		align-items: center;
-		gap: var(--space-8);
+		gap: var(--space-2xs);
 		transition: all 0.3s ease;
 	}
 
@@ -112,7 +112,7 @@ const { header } = Astro.props;
 	.accordion-panel.open {
 		height: auto;
 		opacity: 1;
-		padding: var(--space-32) var(--space-48);
+		padding: var(--space-m) var(--space-l);
 		border-radius: 0 0 8px 8px;
 		background: var(--color-white);
 		border: 1px solid #b8e5e8;

--- a/src/components/mdx/ButtonLink.astro
+++ b/src/components/mdx/ButtonLink.astro
@@ -39,7 +39,7 @@ const { href } = Astro.props;
 	}
 
 	.link-container {
-		margin: var(--space-24) auto;
+		margin: var(--space-s) auto;
 		transition: all 300ms ease-in-out;
 	}
 
@@ -49,7 +49,7 @@ const { href } = Astro.props;
 
 	.styled-link {
 		background-color: var(--color-bright-crimson);
-		padding: var(--space-16) var(--space-24);
+		padding: var(--space-xs) var(--space-s);
 		border-radius: var(--border-radius-base);
 		color: white;
 		font-weight: 400;

--- a/src/components/mdx/FullWidthBackground.astro
+++ b/src/components/mdx/FullWidthBackground.astro
@@ -1,10 +1,18 @@
+---
+interface Props {
+	background?: string;
+}
+
+const { background } = Astro.props;
+---
+
 <style>
 	.full-width-background {
-		width: 100%;
-		max-width: 100vw;
+		width: 100vw;
+		margin-left: calc(50% - 50vw);
 		z-index: 0;
-		grid-column: 1 / 4 !important;
-		margin: var(--space-s) auto var(--space-l);
+		margin-top: var(--space-s);
+		margin-bottom: var(--space-l);
 		background: var(--background, inherit);
 		display: flex;
 		flex-direction: column;
@@ -12,6 +20,9 @@
 	}
 </style>
 
-<section class="full-width-background">
+<section
+	class="full-width-background"
+	style={background ? `--background: ${background}` : undefined}
+>
 	<slot />
 </section>

--- a/src/components/unique/MysteriousVoid.astro
+++ b/src/components/unique/MysteriousVoid.astro
@@ -179,9 +179,9 @@ import FullWidthBackground from "../mdx/FullWidthBackground.astro";
 	.grid-container {
 		display: grid;
 		grid-template-columns: 1fr;
-		gap: var(--space-24);
+		gap: var(--space-s);
 		align-items: center;
-		margin: var(--space-16) 0;
+		margin: var(--space-xs) 0;
 	}
 
 	.styled-image {
@@ -198,8 +198,8 @@ import FullWidthBackground from "../mdx/FullWidthBackground.astro";
 
 	@media (min-width: 850px) {
 		.grid-container {
-			gap: var(--space-64);
-			margin: var(--space-32) 0;
+			gap: var(--space-xl);
+			margin: var(--space-m) 0;
 		}
 	}
 </style>

--- a/src/components/unique/MysteriousVoid.astro
+++ b/src/components/unique/MysteriousVoid.astro
@@ -2,15 +2,14 @@
 import FullWidthBackground from "../mdx/FullWidthBackground.astro";
 ---
 
-<div class="grid-container">
-	<img
-		class="styled-image top-image"
-		src="https://res.cloudinary.com/dxj9qr5gj/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1614174727/maggieappleton.com/notes/learnable-programming/learnprog_2_ieudi6.png"
-		alt="The interface of VS Code – one of the most popular apps for professional programming. If you're writing front-end code, you check the results in a separate browser window."
-	/>
+<img
+	class="mvoid-top-image"
+	src="https://res.cloudinary.com/dxj9qr5gj/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1614174727/maggieappleton.com/notes/learnable-programming/learnprog_2_ieudi6.png"
+	alt="The interface of VS Code – one of the most popular apps for professional programming. If you're writing front-end code, you check the results in a separate browser window."
+/>
 
-	<FullWidthBackground background="#1A1D2F">
-		<div>
+<FullWidthBackground background="#1A1D2F">
+		<div style="padding: var(--space-2xl) 0;">
 			<svg
 				style="max-width: 100%; margin-left: -1rem; z-index: -10;"
 				width="1000px"
@@ -168,38 +167,25 @@ import FullWidthBackground from "../mdx/FullWidthBackground.astro";
 		</div>
 	</FullWidthBackground>
 
-	<img
-		class="styled-image"
-		src="https://res.cloudinary.com/dxj9qr5gj/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1614174727/maggieappleton.com/notes/learnable-programming/learnprog_3_jxgm4k.png"
-		alt="The output of your code appears in a browser window, completely disconnected from the environment where you wrote it"
-	/>
-</div>
+<img
+	class="mvoid-bottom-image"
+	src="https://res.cloudinary.com/dxj9qr5gj/image/upload/c_scale,f_auto,q_auto:good,w_1200/v1614174727/maggieappleton.com/notes/learnable-programming/learnprog_3_jxgm4k.png"
+	alt="The output of your code appears in a browser window, completely disconnected from the environment where you wrote it"
+/>
 
 <style>
-	.grid-container {
-		display: grid;
-		grid-template-columns: 1fr;
-		gap: var(--space-s);
-		align-items: center;
-		margin: var(--space-xs) 0;
-	}
-
-	.styled-image {
+	.mvoid-top-image {
 		width: 100%;
 		height: auto;
 		border-radius: var(--border-radius-base);
-		margin: 0 auto;
 		display: block;
-	}
-
-	.top-image {
 		margin-bottom: -4rem;
 	}
 
-	@media (min-width: 850px) {
-		.grid-container {
-			gap: var(--space-xl);
-			margin: var(--space-m) 0;
-		}
+	.mvoid-bottom-image {
+		width: 100%;
+		height: auto;
+		border-radius: var(--border-radius-base);
+		display: block;
 	}
 </style>

--- a/src/components/unique/apps/Tools.astro
+++ b/src/components/unique/apps/Tools.astro
@@ -8,7 +8,7 @@
 		max-width: 100%;
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-		grid-gap: var(--space-16);
+		grid-gap: var(--space-xs);
 		align-content: center;
 		align-items: center;
 		text-align: center;

--- a/src/global.css
+++ b/src/global.css
@@ -70,19 +70,7 @@
   /* Color scheme for browser UI */
   color-scheme: light dark;
 
-  /* Spacing */
-  --space-4: 0.25rem;
-  --space-8: 0.5rem;
-  --space-12: 0.75rem;
-  --space-16: 1rem;
-  --space-24: 1.5rem;
-  --space-32: 2rem;
-  --space-48: 3rem;
-  --space-64: 4rem;
-  --space-80: 5rem;
-  --space-96: 6rem;
-  --space-128: 8rem;
-  --space-160: 10rem;
+  /* Spacing — use fluid t-shirt sizes (--space-3xs through --space-3xl) defined below */
 
   /* Colors */
   --color-white: #ffffff;
@@ -115,10 +103,10 @@
   --color-crimson-50: color-mix(in srgb, var(--color-bright-crimson) 50%, transparent);
 
   /* Sea blue variants */
-  --color-sea-blue-5: color-mix(in srgb, var(--color-sea-blue) 20%, transparent);
-  --color-sea-blue-10: color-mix(in srgb, var(--color-sea-blue) 30%, transparent);
-  --color-sea-blue-20: color-mix(in srgb, var(--color-sea-blue) 40%, transparent);
-  --color-sea-blue-50: color-mix(in srgb, var(--color-sea-blue) 70%, transparent);
+  --color-sea-blue-20: color-mix(in srgb, var(--color-sea-blue) 20%, transparent);
+  --color-sea-blue-30: color-mix(in srgb, var(--color-sea-blue) 30%, transparent);
+  --color-sea-blue-40: color-mix(in srgb, var(--color-sea-blue) 40%, transparent);
+  --color-sea-blue-70: color-mix(in srgb, var(--color-sea-blue) 70%, transparent);
 
 
   /* Fonts */
@@ -440,7 +428,7 @@ iframe {
 
 body {
   background: var(--color-cream);
-  padding: var(--space-base);
+  padding: var(--space-s);
   color: var(--color-black);
 }
 
@@ -505,7 +493,7 @@ a {
 
 code {
   background: var(--color-cream);
-  padding: var(--space-8) var(--space-12);
+  padding: var(--space-2xs) var(--space-xs);
   border-radius: var(--border-radius-sm);
   font-size: var(--font-size-base);
   line-height: var(--leading-base);
@@ -520,7 +508,7 @@ code {
 pre {
   width: 100%;
   overflow: scroll;
-  padding: var(--space-24) var(--space-32);
+  padding: var(--space-s) var(--space-m);
   border-radius: 0.3em;
   font-size: calc(var(--font-size-sm) * 1.1);
   line-height: var(--leading-loose);
@@ -558,10 +546,10 @@ span.metadata {
 }
 
 button {
-  background-color: var(---color-salmon);
+  background-color: var(--color-salmon);
   border: none;
-  border-radius: var(---border-radius-sm);
-  padding: var(--space-12) var(--space-24);
+  border-radius: var(--border-radius-sm);
+  padding: var(--space-xs) var(--space-s);
 }
 
 mark {

--- a/src/global.css
+++ b/src/global.css
@@ -428,7 +428,6 @@ iframe {
 
 body {
   background: var(--color-cream);
-  padding: var(--space-s);
   color: var(--color-black);
 }
 
@@ -546,7 +545,6 @@ span.metadata {
 }
 
 button {
-  background-color: var(--color-salmon);
   border: none;
   border-radius: var(--border-radius-sm);
   padding: var(--space-xs) var(--space-s);


### PR DESCRIPTION
## Summary

- Fixed `FullWidthBackground` component to properly apply a `background` prop via CSS custom property, and replaced the `grid-column` breakout with a `width: 100vw; margin-left: calc(50% - 50vw)` full-bleed technique
- Restructured `MysteriousVoid.astro` to lift `FullWidthBackground` out of its inner grid wrapper, fixing a Chrome quirk where nested grids caused the `50%` percentage to resolve incorrectly (leaving a gap on the left edge)
- Added vertical padding to the dark SVG section and removed stray `body` padding and hardcoded `button` background-color from `global.css`
- Also includes earlier commits: design system spacing fixes, improved image quality, maintainers page fix, egghead OG image URL migration

## Test plan

- [ ] Visit `/learnable-programming` and confirm the dark blue section spans edge-to-edge at all viewport widths
- [ ] Check `/essays/artisan-data`, `/essays/transcopyright-dreams`, `/essays/growing-a-human` — other `FullWidthBackground` usages should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)