### PR TITLE
Make citation subtext on CSCL note smaller and sans-serif

### DIFF
--- a/src/components/mdx/SimpleCard.astro
+++ b/src/components/mdx/SimpleCard.astro
@@ -70,6 +70,12 @@ const { alignLeft, subtle, padding, margin, ...props } = Astro.props;
 		margin-bottom: var(--space-m);
 	}
 
+	.styled-card :global(.subtext),
+	.styled-card :global(.subtext p) {
+		font-size: var(--font-size-sm);
+		font-family: var(--font-sans);
+	}
+
 	.subtle-card {
 		margin: 0 auto var(--space-s);
 		box-shadow: var(--box-shadow-sm);

--- a/src/content/notes/cscl.mdx
+++ b/src/content/notes/cscl.mdx
@@ -54,10 +54,10 @@ Computer magic means we can have multiple, intertwining discussions all going on
 
 "Collaborative Learning does not just mean that individual learning is enhanced by participation in small groups; <mark>it means that it is the groups themselves that learn."</mark> Knowledge is a product of the collaboration process: it <b>arises through interaction of different perspectives</b>, heats up in the cauldron of public discourse, is gradually refined through negotiation, and is <b>codified and preserved in cultural or scientific artifacts</b>"
 
-<p className="subtext">
+<div className="subtext">
 	Computer Support For Collaborative Learning: Foundations for a CSCL Community
 	– [Stahl (2002)](http://www.gerrystahl.net/hci/cscl2002intro.pdf)
-</p>
+</div>
 
 </SimpleCard>
 
@@ -65,10 +65,10 @@ Computer magic means we can have multiple, intertwining discussions all going on
 
 "Collaboration leads to positive outcomes only when students engage in **knowledge generative interactions** such as **giving explanations**, and engaging in **argumentation, negotiation, conflict resolution or mutual regulation**""
 
-<p className="subtext">
+<div className="subtext">
 	Designing Integrative Scripts – [Dillenbourg and Jermann
 	(2007)](https://www.researchgate.net/publication/227598981_Designing_Integrative_Scripts)
-</p>
+</div>
 
 </SimpleCard>
 
@@ -76,11 +76,11 @@ Computer magic means we can have multiple, intertwining discussions all going on
 
 "The occurrence of **knowledge-generative interactions** is not a given: such <mark>interactions do not necessarily emerge spontaneously"</mark> (Cohen 1994; Salomon and Globerson 1989)
 
-<p className="subtext">
+<div className="subtext">
 	Computer Supported Collaborative Learning and Intelligent Tutoring Systems –
 	[Tchounikine, Rummel, and McLaren
 	(2010)](https://www.cs.cmu.edu/~bmclaren/pubs/TchounikineEtAl-CSCLandITS-ITSBook2010.pdf)
-</p>
+</div>
 
 </SimpleCard>
 
@@ -112,11 +112,11 @@ There's also a need for a fine balance of structure and improvisation. If script
 
 "CSCL scripts are primarily considered as support devices enabling learners to **stick to an effective pattern of collaboration more easily** and to obtain improved learning outcomes" (156)
 
-<p className="subtext">
+<div className="subtext">
 	Scripting Computer-Supported Collaborative Learning: Cognitive,
 	Computationaland Educational Perspectives – [Fischer, F. et al.
 	(2007)](https://www.researchgate.net/publication/321610653_Scripting_Computer-Supported_Collaborative_Learning_Cognitive_Computational_and_Educational_Perspectives)
-</p>
+</div>
 
 </SimpleCard>
 
@@ -124,11 +124,11 @@ There's also a need for a fine balance of structure and improvisation. If script
 
 "Free collaboration does not systematically produce learning. One way to enhance the effectiveness of collaborative learning is to **structure interactions by engaging students in well-defined scripts**. A collaboration script is a set of instructions prescribing how students should form groups, how they should interact and collaborate and how they should solve the problem"
 
-<p className="subtext">
+<div className="subtext">
 	Over-scripting CSCL: The risks of blending collaborative learning
 	withinstructional design – [Dillenbourg
 	(2002)](https://pdfs.semanticscholar.org/1556/e5d2f93f6400457b422a011d7d93a3aa29fe.pdf)
-</p>
+</div>
 
 </SimpleCard>
 


### PR DESCRIPTION
## Summary
- Style the `.subtext` citation lines inside `SimpleCard` quote blocks at `--font-size-sm` and `--font-sans` so they read as captions rather than body copy.
- Switch the citations in `notes/cscl.mdx` from `<p className="subtext">` to `<div className="subtext">` because MDX was splitting the multi-line markdown content into an empty `<p class="subtext"></p>` followed by a separate unclassed `<p>`, which is why the styling appeared not to apply.

## Test plan
- [ ] Visit `/cscl/` and confirm each citation under the quote cards renders smaller and sans-serif.
- [ ] Confirm other usages of `SimpleCard` across the site are visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)