### PR TITLE
Stop InvisiblesFeature images stretching to fill grid row

### DIFF
--- a/src/components/unique/InvisiblesFeature.astro
+++ b/src/components/unique/InvisiblesFeature.astro
@@ -63,8 +63,16 @@ if (typeof imageURL === "string" && imageURL.startsWith("/images")) {
 		margin-top: 0;
 	}
 
-	.invisibles-feature-container img {
+	.invisibles-feature-container :global(img) {
 		border-radius: 5px;
+		width: 100%;
+		height: auto;
+		align-self: start;
+		object-fit: contain;
+	}
+
+	.invisibles-feature-container :global(picture) {
+		align-self: start;
 	}
 
 	@media (max-width: 768px) {


### PR DESCRIPTION
## Summary

Follow-up to #89. The 1000×1000 illustrations were being stretched vertically because the parent grid's default `align-items: stretch` combined with no `height: auto` on the img made them fill the full row height. Adds `align-self: start` and `height: auto` so images render at their natural aspect ratio.

## Test plan

- [ ] Visit `/drawinginvisibles1`, confirm Matt Chase + Emiliano Ponzi images render at correct aspect ratios

🤖 Generated with [Claude Code](https://claude.com/claude-code)