### PR TITLE
content: add 'The Post Pull Request World' seedling note

### DIFF
--- a/src/content/notes/post-pull-request.mdx
+++ b/src/content/notes/post-pull-request.mdx
@@ -1,0 +1,26 @@
+---
+title: "The Post Pull Request World"
+description: "..."
+startDate: "2026-04-30"
+updated: "2026-04-30"
+type: "note"
+topics: ["Design", "Artificial Intelligence"]
+growthStage: "budding"
+draft: true
+---
+
+## Problem and consequences
+
+Pull requests don't fit the shape of agentic development. A PR is a request with the wrong information. Not enough context – the why, the resonsing, how this came to be, alternate paths considered, rounds of review its been through, level of rigour. Missing the agentic information. 
+
+## Shape of the solution
+
+New primitives that capture the context, conversation, and commits of an agent session.
+
+Session - conversation with an agent that let to outputs: code commits, documents.
+
+Checkpoints - light weight review and approval gates
+
+Trails - audit trails of exactly what happened, archived as historical context for future work
+
+Chronicles – natural language summaries, explainers, and contextualised overviews of an agent session

--- a/src/links.json
+++ b/src/links.json
@@ -2473,6 +2473,16 @@
   },
   {
     "ids": [
+      "The Post Pull Request World"
+    ],
+    "slug": "post-pr",
+    "growthStage": "seedling",
+    "description": "...",
+    "outboundLinks": [],
+    "inboundLinks": []
+  },
+  {
+    "ids": [
       "Problematic Proteins"
     ],
     "slug": "problematic-proteins",


### PR DESCRIPTION
Adds a new draft seedling note exploring why pull requests don't fit the shape of agentic development, and sketches new primitives (sessions, checkpoints, trails, chronicles) that could replace them. Also registers the note in src/links.json.