### PR TITLE
[ai] Fix unfinished and inaccurate prose in block-party essay

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -659,9 +659,9 @@ These projects are all spiritual predecesors in this story. The interfaces patte
 
 <h5 style={{ marginTop: "-0.6rem" }}>1987-1997</h5>
 
-By the late 1980s, the personal computing revolution was in full swing. Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail. Gates was xxx
+By the late 1980s, the personal computing revolution was in full swing. Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail. Microsoft was eating the operating-system world.
 
-The first meaningful project in this period was Hypercard which .
+The first meaningful project in this period was HyperCard, Bill Atkinson's 1987 software for Apple, which let users build linked stacks of cards containing text, images, and scripted buttons — the first widely-used hypermedia authoring tool that didn't require programming.
 
 [image of hypercard]
 
@@ -679,7 +679,7 @@ Apple stepped up with a vision that aimed to compete with OLE, but took the idea
 
 [OpenDoc diagram]
 
-the first OpenDoc-based product release was Apple's CyberDog web browser in May 1996. It died along with Hypercard in 1997
+the first OpenDoc-based product release was Apple's CyberDog web browser in May 1996. OpenDoc died in 1997, after Steve Jobs returned to Apple and cut it. HyperCard limped on in maintenance mode until Apple finally pulled the plug in 2004.
 
 If we're just going off the promotional videos, OpenDoc is the clear winner in this popularity contest:
 
@@ -708,7 +708,7 @@ Tumblr was at the height of its popularity. The web was interactive and Web 2.0 
 Notion released version 2.0 in 2018. In this context, despite being the most visible and widely used block-editor to date, Notion was quite late to the game.
 It's undeniable Notion has been the most influential platform championing and pushing the boundaries of block-based editing in recent years.
 
-Wordpress started work on Gutenberg in 2017(?) and released its first version in 2018(?).
+Wordpress announced Gutenberg in June 2017 and shipped it in WordPress 5.0 on December 6, 2018.
 
 Notion's first release in 2018 kicked things into high gear here. While Wordpress Gutenberg has been out for X years, it served a small use case; writing blog posts. Notion reframed the block editor as an everyday tool – a place to write collaborative documents for your team, or even just yourself. It turned it into an editor you live in, rather than a publishing tool for a specific purpose.
 

--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -661,7 +661,7 @@ These projects are all spiritual predecesors in this story. The interfaces patte
 
 By the late 1980s, the personal computing revolution was in full swing. Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail. Microsoft was eating the operating-system world.
 
-The first meaningful project in this period was HyperCard, Bill Atkinson's 1987 software for Apple, which let users build linked stacks of cards containing text, images, and scripted buttons — the first widely-used hypermedia authoring tool that didn't require programming.
+The first meaningful project in this period was HyperCard, Bill Atkinson's 1987 software for Apple, which let users build linked stacks of cards containing text, images, and scripted buttons. It was the first widely-used hypermedia authoring tool that didn't require programming.
 
 [image of hypercard]
 


### PR DESCRIPTION
## Implements

Closes #94

## Parent plan

#92

## What changed

- Replaced the stub `"Gates was xxx"` with `"Microsoft was eating the operating-system world."`
- Completed the truncated HyperCard sentence with an accurate description of Bill Atkinson's 1987 hypermedia tool
- Fixed the OpenDoc/HyperCard death-date error: OpenDoc was killed in 1997 (after Jobs returned), HyperCard in 2004 — not both in 1997
- Removed `(?)` uncertainty markers from the Gutenberg dates; replaced with definitive statements (announced June 2017, shipped in WordPress 5.0 on December 6, 2018)

## How to verify

- Open `src/content/essays/block-party.mdx` and search for `xxx`, `(?)` — neither should appear in the Second or Third Age sections
- Confirm the HyperCard paragraph around L664 reads as a complete sentence
- Confirm L682 correctly attributes 1997 to OpenDoc and 2004 to HyperCard
- Run the dev server and navigate to the essay; MDX should render without errors

## Notes

Changes are purely prose corrections — no structural MDX changes, no component additions. Stayed scoped to the four specific lines called out in the sub-issue; did not touch other known placeholders or incomplete sections (those are separate sub-issues under #92).




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176259723/agentic_workflow) for issue #94 · ● 139.3K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176259723, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176259723 -->

<!-- gh-aw-workflow-id: implementer -->