### PR TITLE
[ai] Remove unfillable image placeholders from block-party essay

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -324,8 +324,6 @@ Beyond those essentials, its open game. Some editors distinguish themselves by o
 
 There seems to be no ceiling to the complexity level we're willing to wrap up into a single block. Some could be standalone apps in their own right. Kanban boards, image galleries, live coding environments, and fully decked-out spreadsheets that function as relational databases can all be encapsulated into a “block”. This extends to embeds which allow users to stick the whole of Google Maps, Figma, or Airtable into a document.
 
-<RemoteImage src="https://via.placeholder.com/600x300" alt="" />
-
 [spectrum of simple to complex blocks]
 
 <div style={{display: "inline-block", marginTop: "3rem"}}>
@@ -373,8 +371,6 @@ direct manipulation you can drag and drop them into new positions, making it qui
 to restructure a document without faffing about with precise text selection.
 
 </div>
-
-[visual for drag and drop]
 
 <div style={{display: "inline-block", marginTop: "3rem"}}>
 
@@ -510,8 +506,6 @@ To reduce any confusion, let's also make clear what blocks are _not_. Within the
 - An entry on a blockchain ledger, or anything to do with Web3 blockchain hype. Please take that party elsewhere.
 - A specific technical implementation; they are not the same as React components, Web Components, or software components. They are a conceptual idea about how we present editable content to end-users of the web.
 
-[cartoon sketch of a block as a higher interface concept, possibly implemented in WC/React/etc, but not concerned with implementation. And nothing to do with the blockchain]
-
 The blocks I am talking about here are an interface pattern. How that pattern is implemented is beyond the scope of this article and my limited knowledge as a pseudo-engineer. I'm interested in blocks from a user and interface designer perspective, rather than a web infrastructure perspective. <Footnote idName={6}>There is plenty to be said about the technical challenges of how we could/should build interoperable blocks built on solid web standards, but I'll leave that to someone else. Perhaps you?</Footnote>
 
 ## The Benefits of Blocks
@@ -582,10 +576,6 @@ Formatting at the character level gives us an enormous amount of granular contro
 Classical documents might format at the character level, but they organise at the document level. The document is the entity you reference when you link to your work or reference it by name.
 
 A block can be dragged and dropped into a new position on the page. It can be swapped for another type of block without changing its content. It can be copied and pasted into a different document without losing its content and structure.
-
-<RemoteImage src="https://via.placeholder.com/600x300" alt="" />
-
-[annotated diagram of swapping blocks and dragging and dropping blocks]
 
 Blocks open up a world of flexibility and interactive power within a scoped area. They're easier to move around – a key quality for anyone working with ideas who needs to arrange and rearrange information in relationships to find the right groupings and sequences – which is to say, all of us doing knowledge work.
 
@@ -757,8 +747,6 @@ We've already been moving swiftly in this direction in the larger context of fro
 The same will happen with blocks, which are a simply a very specific type of component – one designed for authoring documents on the web.
 
 A big disclaimer on this one. I lead design at HASH, where one of our projects is the Block Protocol – a standardised way for blocks to communicate with their embedding applications (aka. block-editors)
-
-[ diagram ]
 
 I certainly have a vested interest in the block ecosystem diversifying and maturing.
 


### PR DESCRIPTION
## Implements

Closes #95

## Parent plan

#92

## What changed

- Removed `via.placeholder.com` image at L327 (L329 already had the `[spectrum...]` label)
- Cut `[visual for drag and drop]` at L377 — prose fully conveys direct manipulation
- Deleted `[cartoon sketch of block concept]` at L513 — decorative-only, prose stands alone
- Removed `via.placeholder.com` + `[annotated diagram]` at L586–588 — duplicate of the swap visual
- Deleted `[ diagram ]` at L761 for the Block Protocol — outdated reference

## How to verify

- `grep -n "via.placeholder.com" src/content/essays/block-party.mdx` returns no results
- Read the surrounding paragraphs at each removed location — prose flows naturally without orphaned "as shown above/below" references
- MDX renders without errors (no broken JSX tags were introduced)

## Notes

All five removals are straight deletions — no prose was rewritten. The surrounding text already reads cleanly without the placeholders. The `[spectrum of simple to complex blocks]` label on L329 was kept because it likely corresponds to a real diagram to be created in a future PR (per the parent plan's Figma work).




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176260956/agentic_workflow) for issue #95 · ● 93.3K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176260956, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176260956 -->

<!-- gh-aw-workflow-id: implementer -->