### PR TITLE
[ai] Fix incomplete "Gates was xxx" sentence in block-party essay

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -659,7 +659,7 @@ These projects are all spiritual predecesors in this story. The interfaces patte
 
 <h5 style={{ marginTop: "-0.6rem" }}>1987-1997</h5>
 
-By the late 1980s, the personal computing revolution was in full swing. Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail. Gates was xxx
+By the late 1980s, the personal computing revolution was in full swing. Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail.
 
 The first meaningful project in this period was Hypercard which .
 


### PR DESCRIPTION
## Implements

Closes #105

## Parent plan

#94

## What changed

- Removed the dangling incomplete sentence `Gates was xxx` from the end of the paragraph at L662 in `src/content/essays/block-party.mdx`
- The surrounding context ("Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail.") already conveys the era adequately without it

## How to verify

- Open `src/content/essays/block-party.mdx` and confirm no `xxx` placeholder remains
- The paragraph in the "Second Age of Blocks" section now ends cleanly at "...a floppy of Oregon Trail."
- File renders without MDX errors

## Notes

Chose the cut approach (removing the sentence entirely) rather than the replacement suggestion ("Microsoft was eating the operating-system world."), as the surrounding prose already establishes the era and adding a new sentence would require sourcing/fact-checking.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176518430/agentic_workflow) for issue #105 · ● 51.4K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176518430, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176518430 -->

<!-- gh-aw-workflow-id: implementer -->