### PR TITLE
[ai] fix: remove via.placeholder.com broken image URLs from block-party.mdx

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -324,8 +324,6 @@ Beyond those essentials, its open game. Some editors distinguish themselves by o
 
 There seems to be no ceiling to the complexity level we're willing to wrap up into a single block. Some could be standalone apps in their own right. Kanban boards, image galleries, live coding environments, and fully decked-out spreadsheets that function as relational databases can all be encapsulated into a “block”. This extends to embeds which allow users to stick the whole of Google Maps, Figma, or Airtable into a document.
 
-<RemoteImage src="https://via.placeholder.com/600x300" alt="" />
-
 [spectrum of simple to complex blocks]
 
 <div style={{display: "inline-block", marginTop: "3rem"}}>
@@ -582,10 +580,6 @@ Formatting at the character level gives us an enormous amount of granular contro
 Classical documents might format at the character level, but they organise at the document level. The document is the entity you reference when you link to your work or reference it by name.
 
 A block can be dragged and dropped into a new position on the page. It can be swapped for another type of block without changing its content. It can be copied and pasted into a different document without losing its content and structure.
-
-<RemoteImage src="https://via.placeholder.com/600x300" alt="" />
-
-[annotated diagram of swapping blocks and dragging and dropping blocks]
 
 Blocks open up a world of flexibility and interactive power within a scoped area. They're easier to move around – a key quality for anyone working with ideas who needs to arrange and rearrange information in relationships to find the right groupings and sequences – which is to say, all of us doing knowledge work.
 


### PR DESCRIPTION
## Implements

Closes #102

## Parent plan

#95

## What changed

- Removed `<RemoteImage src="(via.placeholder.com/redacted) alt="" />` at line ~327 (the `[spectrum of simple to complex blocks]` label beneath it is retained as it still conveys intent)
- Removed both the `<RemoteImage>` placeholder and the `[annotated diagram of swapping blocks and dragging and dropping blocks]` label at lines ~586–588
- No surrounding prose was altered; blank lines introduced by the deletions were cleaned up

## How to verify

- `grep -r "via.placeholder.com" src/content/essays/block-party.mdx` — should return no matches
- Open the essay locally and confirm both sections read naturally without visual gaps

## Notes

The `[spectrum of simple to complex blocks]` bracket label was kept intentionally — the sub-issue specifies only the placeholder image was redundant at that location. The `[annotated diagram]` label at line 588 was removed together with its image per the acceptance criteria.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176505411/agentic_workflow) for issue #102 · ● 66.1K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176505411, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176505411 -->

<!-- gh-aw-workflow-id: implementer -->