### PR TITLE
[ai] Move and replace Hash disclaimer block in block-party.mdx

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -43,6 +43,12 @@ People who design and build websites, apps, and interfaces. Likely ones related 
 
 </AssumedAudience>
 
+<Disclaimer>
+
+I used to work at HASH (focused on the [Block Protocol](blockprotocol.org) project) for eight months. This essay and its research are my personal work and opinion, written on my own time; no one at HASH was involved.
+
+</Disclaimer>
+
 <Spacer size="small" />
 
 <IntroParagraph>Over the last five years, our digital documents and pages have taken on a strange shape. They have become noticeably _blocky_.</IntroParagraph>
@@ -719,20 +725,6 @@ These editors are sometimes belittled as “Notion clones", although Notion was 
 ## Block to the Future
 
 We have made it through our blocky past and present. Which brings us to the part everyone clamours for. _But what is the future?_ What is the point of reciting history, if not to try and find patterns that point to what happens next? Let's march forwards with our rear-view mirror in hand.
-
-<Disclaimer>
-
-I used to work at [HASH](https://hash.ai) – a company specifically focused on
-expanding the block ecosystem via the [Block
-Protocol](https://blockprotocol.org) project. While I've moved on to a new
-role, I still support the efforts of the project and believe it's a worthwhile
-idea to pursue.
-This essay and all the research associated with it is my own personal work and
-opinion. I wrote it on my own time, and no one else at HASH was involved in
-its creation. Nevertheless, you should take all my predictions and
-pro-block enthusiasm with a grain of salt.
-
-</Disclaimer>
 
 ### Future patterns
 


### PR DESCRIPTION
## Implements

Closes #106

## Parent plan

#93

## What changed

- Moved the HASH disclaimer from its buried position mid-essay (after the "Block to the Future" heading, ~L723) to immediately after `<AssumedAudience>` and before the first `<IntroParagraph>`
- Replaced the original multi-sentence disclaimer with the shorter, clearer version: "I used to work at HASH (focused on the [Block Protocol](blockprotocol.org) project) for eight months. This essay and its research are my personal work and opinion, written on my own time; no one at HASH was involved."
- Removed the old `<Disclaimer>` block entirely from its former location

## How to verify

- Open the rendered essay and confirm the disclaimer appears near the top, right after the assumed-audience box and before the intro paragraph
- Confirm "Over the last five years..." remains the opening of the `<IntroParagraph>` (unchanged)
- No MDX parse errors on build

## Notes

The `<Disclaimer>` component was already imported and in use elsewhere in the file, so no import changes were needed. The Spacer between the disclaimer and `<IntroParagraph>` was left in place.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176518433/agentic_workflow) for issue #106 · ● 85.5K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176518433, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176518433 -->

<!-- gh-aw-workflow-id: implementer -->