### PR TITLE
[ai] Fix duplicate footnote idName collision in block-party.mdx

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -480,7 +480,7 @@ For example, Roam allows you to embed blocks inside one another and see the back
 
 ---
 
-Like all good software designers, the people creating these new editors are following [Jakob's Law](https://www.nngroup.com/videos/jakobs-law-internet-ux/) of internet user experience; people spend 99% of their time on websites _other than yours_. You'll make their lives far easier if you use design patterns they're already familiar with. While many will grumble the similarities between block-editors speaks to a lack of “innovation”, <Footnote idName={3}> “Innovate” | ˈɪnəveɪt | verb. To flagrantly disregard previous historical work and established conventions that have survived the test of time. Results may vary. </Footnote> the industry converging around a set of standards is a net gain for both users and creators.
+Like all good software designers, the people creating these new editors are following [Jakob's Law](https://www.nngroup.com/videos/jakobs-law-internet-ux/) of internet user experience; people spend 99% of their time on websites _other than yours_. You'll make their lives far easier if you use design patterns they're already familiar with. While many will grumble the similarities between block-editors speaks to a lack of “innovation”, <Footnote idName={7}> “Innovate” | ˈɪnəveɪt | verb. To flagrantly disregard previous historical work and established conventions that have survived the test of time. Results may vary. </Footnote> the industry converging around a set of standards is a net gain for both users and creators.
 
 ## What _exactly_ is a block?
 


### PR DESCRIPTION
## Implements

Closes #108

## Parent plan

#93

## What changed

- Scanned all `Footnote idName` values in `src/content/essays/block-party.mdx` — found values 1, 2, 3, 4, 5, 6, 8 in use; 7 was unused
- The footnote at L483 ("Innovate | verb...") reused `idName={3}`, colliding with the footnote at L198
- Renumbered the L483 footnote to `idName={7}` — the next available unused integer
- All other footnote `idName` values are unchanged

## How to verify

- Run `grep -n "idName=" src/content/essays/block-party.mdx` and confirm no two lines share the same number
- Build the site and open the block-party essay; footnotes should render without MDX errors

## Notes

There is an additional `idName={1}` at L791 that also duplicates the L50 footnote, but that is outside the scope of this sub-issue (the acceptance criteria only cover L483). It can be addressed in a follow-up.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176518941/agentic_workflow) for issue #108 · ● 79.5K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176518941, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176518941 -->

<!-- gh-aw-workflow-id: implementer -->