### PR TITLE
[ai] Remove text-only visual placeholder brackets from block-party.mdx

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -374,8 +374,6 @@ to restructure a document without faffing about with precise text selection.
 
 </div>
 
-[visual for drag and drop]
-
 <div style={{display: "inline-block", marginTop: "3rem"}}>
 
 <svg
@@ -509,8 +507,6 @@ To reduce any confusion, let's also make clear what blocks are _not_. Within the
 
 - An entry on a blockchain ledger, or anything to do with Web3 blockchain hype. Please take that party elsewhere.
 - A specific technical implementation; they are not the same as React components, Web Components, or software components. They are a conceptual idea about how we present editable content to end-users of the web.
-
-[cartoon sketch of a block as a higher interface concept, possibly implemented in WC/React/etc, but not concerned with implementation. And nothing to do with the blockchain]
 
 The blocks I am talking about here are an interface pattern. How that pattern is implemented is beyond the scope of this article and my limited knowledge as a pseudo-engineer. I'm interested in blocks from a user and interface designer perspective, rather than a web infrastructure perspective. <Footnote idName={6}>There is plenty to be said about the technical challenges of how we could/should build interoperable blocks built on solid web standards, but I'll leave that to someone else. Perhaps you?</Footnote>
 
@@ -757,8 +753,6 @@ We've already been moving swiftly in this direction in the larger context of fro
 The same will happen with blocks, which are a simply a very specific type of component – one designed for authoring documents on the web.
 
 A big disclaimer on this one. I lead design at HASH, where one of our projects is the Block Protocol – a standardised way for blocks to communicate with their embedding applications (aka. block-editors)
-
-[ diagram ]
 
 I certainly have a vested interest in the block ecosystem diversifying and maturing.
 


### PR DESCRIPTION
## Implements

Closes #103

## Parent plan

#95

## What changed

- Removed `[visual for drag and drop]` (was line 377) — prose already conveys the drag-and-drop concept
- Removed `[cartoon sketch of block concept]` (was line 513) — prose stands alone; purely decorative
- Removed `[ diagram ]` for Block Protocol (was line 761) — outdated reference that dates the piece
- Cleaned up the surrounding blank lines at each cut so no stray double-blanks remain

## How to verify

1. Open `src/content/essays/block-party.mdx` and search for `[visual`, `[cartoon`, and `[ diagram` — none should appear
2. Check the surrounding prose at each former location reads naturally
3. Render the essay locally and confirm no MDX errors

## Notes

Each placeholder sat on its own line between two blank lines; one blank line was preserved at each location for normal paragraph spacing. No surrounding prose sentences were touched.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176506842/agentic_workflow) for issue #103 · ● 144.1K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176506842, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176506842 -->

<!-- gh-aw-workflow-id: implementer -->