### PR TITLE
[ai] Third Age section: remove Tumblr line and consolidate Notion paragraphs

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -701,20 +701,13 @@ These are two useful landmarks to pay attention to, but it would be insincere to
 
 From the start of “Web 2.0” in the mid-2000s block-like objects began to appear on our newly invented _web apps_ – websites that allowed users to dynamically interact with the page without refreshing or reloading it.
 
-Tumblr is worth mentioning here.
-
-Tumblr was at the height of its popularity. The web was interactive and Web 2.0 was in full swing. More and more people needed accessible tools to publish content to the web.
-
 Notion released version 2.0 in 2018. In this context, despite being the most visible and widely used block-editor to date, Notion was quite late to the game.
-It's undeniable Notion has been the most influential platform championing and pushing the boundaries of block-based editing in recent years.
 
 Wordpress started work on Gutenberg in 2017(?) and released its first version in 2018(?).
 
-Notion's first release in 2018 kicked things into high gear here. While Wordpress Gutenberg has been out for X years, it served a small use case; writing blog posts. Notion reframed the block editor as an everyday tool – a place to write collaborative documents for your team, or even just yourself. It turned it into an editor you live in, rather than a publishing tool for a specific purpose.
+It's undeniable Notion has been the most influential platform championing and pushing the boundaries of block-based editing in recent years. While Wordpress Gutenberg served a small use case — writing blog posts — Notion reframed the block editor as an everyday tool: a place to write collaborative documents for your team, or even just yourself. It turned it into an editor you live in, rather than a publishing tool for a specific purpose. It became a touchstone reference point – a software category in its own right. Like _Uber for X_, we now have _Notion, but with Y feature_.
 
-It is exceptionally ironic that when Micrososoft announced their new project "Microsoft Loop” in X, it was lambasted across Twitter as a “shameless Notion clone."
-
-These editors are sometimes belittled as “Notion clones", although Notion was not the first or last platform to implement the conceptual model of documents composed of blocks. Nevertheless, it became a touchstone reference point – a software category in its own right. Like _Uber for X_, we now have _Notion, but with Y feature_.
+It is exceptionally ironic that when Micrososoft announced their new project “Microsoft Loop” in X, it was lambasted across Twitter as a “shameless Notion clone.”
 
 ## Block to the Future
 


### PR DESCRIPTION
## Implements

Closes #116

## Parent plan

#99

## What changed

- Removed the dangling "Tumblr is worth mentioning here." line and its orphaned follow-up sentence at L704–706
- Identified three separate paragraphs all making the same "Notion was the most influential" claim (L708–709, L713, L717)
- Merged those three into one consolidated paragraph using the best phrasing from each: the "most influential" framing, the everyday-tool contrast with Gutenberg, and the touchstone/software-category point
- Kept the Gutenberg timeline fact and the Microsoft Loop irony note as separate paragraphs — they are distinct points, not repetitions

## How to verify

- Open `src/content/essays/block-party.mdx` and search for "Tumblr" — should find zero occurrences in the Third Age section
- Search for "most influential" — should appear exactly once in the section
- Read lines ~692–712 in the updated file; the prose should flow without orphaned transitions

## Notes

The edit is purely a tightening pass using existing text — no new writing was added. The Gutenberg comparison ("While Gutenberg served a small use case — writing blog posts") was drawn from L713 and folded into the consolidated paragraph to preserve the contrast that explains *why* Notion was influential.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176551377/agentic_workflow) for issue #116 · ● 120.1K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176551377, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176551377 -->

<!-- gh-aw-workflow-id: implementer -->