### PR TITLE
[ai] Fix "Gates was xxx" placeholder in block-party.mdx

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -659,7 +659,7 @@ These projects are all spiritual predecesors in this story. The interfaces patte
 
 <h5 style={{ marginTop: "-0.6rem" }}>1987-1997</h5>
 
-By the late 1980s, the personal computing revolution was in full swing. Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail. Gates was xxx
+By the late 1980s, the personal computing revolution was in full swing. Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail.
 
 The first meaningful project in this period was Hypercard which .
 


### PR DESCRIPTION
## Implements

Closes #126

## Parent plan

#105

## What changed

- Removed the dangling incomplete sentence `Gates was xxx` from line 662 of `src/content/essays/block-party.mdx`
- The paragraph now ends cleanly at `...Families could afford their own Macintosh and a floppy of Oregon Trail.`
- No other `xxx` placeholders exist in the file

## How to verify

- Open `src/content/essays/block-party.mdx` and confirm line 662 no longer contains `Gates was xxx`
- Run `grep -n "xxx" src/content/essays/block-party.mdx` — should return no matches
- Start the dev server and navigate to the block-party essay to confirm it renders without MDX errors

## Notes

Chose the "cut" version per the issue's preferred fix. The surrounding sentences (`Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail.`) already establish the era adequately without needing the Microsoft reference.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176735250/agentic_workflow) for issue #126 · ● 46.4K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176735250, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176735250 -->

<!-- gh-aw-workflow-id: implementer -->