### PR TITLE
[ai] Complete incomplete HyperCard sentence in block-party.mdx

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -661,7 +661,7 @@ These projects are all spiritual predecesors in this story. The interfaces patte
 
 By the late 1980s, the personal computing revolution was in full swing. Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail. Gates was xxx
 
-The first meaningful project in this period was HyperCard, Bill Atkinson's 1987 software for Apple, which let users build linked stacks of cards containing text, images, and scripted buttons — the first widely-used hypermedia authoring tool that didn't require programming.
+The first meaningful project in this period was HyperCard, Bill Atkinson's 1987 software for Apple, which let users build linked stacks of cards containing text, images, and scripted buttons. It was the first widely-used hypermedia authoring tool that didn't require programming.
 
 [image of hypercard]
 

--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -661,7 +661,7 @@ These projects are all spiritual predecesors in this story. The interfaces patte
 
 By the late 1980s, the personal computing revolution was in full swing. Boxy white DELL's graced every modern office desk. Families could afford their own Macintosh and a floppy of Oregon Trail. Gates was xxx
 
-The first meaningful project in this period was Hypercard which .
+The first meaningful project in this period was HyperCard, Bill Atkinson's 1987 software for Apple, which let users build linked stacks of cards containing text, images, and scripted buttons — the first widely-used hypermedia authoring tool that didn't require programming.
 
 [image of hypercard]
 


### PR DESCRIPTION
## Implements

Closes #107

## Parent plan

#94

## What changed

- Replaced the stub sentence `The first meaningful project in this period was Hypercard which .` at L664 with a complete, accurate description of HyperCard
- Corrected capitalisation from `Hypercard` → `HyperCard` (Apple's official spelling)
- Sentence now covers Bill Atkinson, the 1987 release date, the card-stack model, and HyperCard's historical significance as the first widely-used hypermedia authoring tool

## How to verify

- Open `src/content/essays/block-party.mdx` and confirm L664 reads the full HyperCard sentence
- Run the site locally (`npm run dev`) and navigate to the Block Party essay; the Second Age section should render without MDX errors and display the complete sentence

## Notes

Only L664 was in scope for this sub-issue. The other stubs in the same section (L662 `Gates was xxx`, L682 OpenDoc/HyperCard death dates, L711 Gutenberg dates) are covered by sibling sub-issues under parent plan #94.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176519069/agentic_workflow) for issue #107 · ● 48K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176519069, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176519069 -->

<!-- gh-aw-workflow-id: implementer -->