### PR TITLE
[ai] Fix OpenDoc and HyperCard death dates in block-party essay

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -679,7 +679,7 @@ Apple stepped up with a vision that aimed to compete with OLE, but took the idea
 
 [OpenDoc diagram]
 
-the first OpenDoc-based product release was Apple's CyberDog web browser in May 1996. It died along with Hypercard in 1997
+the first OpenDoc-based product release was Apple's CyberDog web browser in May 1996. OpenDoc died in 1997, after Steve Jobs returned to Apple and cut it. HyperCard limped on in maintenance mode until Apple finally pulled the plug in 2004.
 
 If we're just going off the promotional videos, OpenDoc is the clear winner in this popularity contest:
 


### PR DESCRIPTION
## Implements

Closes #110

## Parent plan

#94

## What changed

- Removed the erroneous sentence "It died along with Hypercard in 1997" from `src/content/essays/block-party.mdx` (L682)
- Added accurate sentence stating OpenDoc died in 1997 after Steve Jobs returned to Apple and cut it
- Added accurate sentence stating HyperCard continued in maintenance mode until Apple discontinued it in 2004

## How to verify

- Search for `It died along with Hypercard in 1997` in `block-party.mdx` — should return no results
- Confirm the paragraph at the former L682 now reads: *"OpenDoc died in 1997, after Steve Jobs returned to Apple and cut it. HyperCard limped on in maintenance mode until Apple finally pulled the plug in 2004."*
- Run the dev server (`npm run dev`) and navigate to the block-party essay to confirm the page renders without MDX errors

## Notes

Purely a factual text correction — no code or component changes. The fix matches the exact replacement text specified in the sub-issue acceptance criteria.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176520047/agentic_workflow) for issue #110 · ● 51.9K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176520047, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176520047 -->

<!-- gh-aw-workflow-id: implementer -->