### PR TITLE
[ai] Remove broken via.placeholder.com image from block-party.mdx

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -324,8 +324,6 @@ Beyond those essentials, its open game. Some editors distinguish themselves by o
 
 There seems to be no ceiling to the complexity level we're willing to wrap up into a single block. Some could be standalone apps in their own right. Kanban boards, image galleries, live coding environments, and fully decked-out spreadsheets that function as relational databases can all be encapsulated into a “block”. This extends to embeds which allow users to stick the whole of Google Maps, Figma, or Airtable into a document.
 
-<RemoteImage src="https://via.placeholder.com/600x300" alt="" />
-
 [spectrum of simple to complex blocks]
 
 <div style={{display: "inline-block", marginTop: "3rem"}}>


### PR DESCRIPTION
## Implements

Closes #129

## Parent plan

#102

## What changed

- Deleted the `<RemoteImage src="(via.placeholder.com/redacted) alt="" />` element at ~line 327 of `src/content/essays/block-party.mdx`
- Removed the trailing blank line that would have created a double blank line after deletion
- Surrounding prose and the `[spectrum of simple to complex blocks]` reference at the adjacent line are untouched

## How to verify

- `grep "via.placeholder.com" src/content/essays/block-party.mdx` returns no matches
- View the essay around the "no ceiling to complexity" paragraph — the spectrum reference renders cleanly with no spacing artifacts

## Notes

The placeholder image was a stub with no alt text and no visible content — purely a broken placeholder. No functional change to the essay content.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176755830/agentic_workflow) for issue #129 · ● 53.9K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176755830, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176755830 -->

<!-- gh-aw-workflow-id: implementer -->