### PR TITLE
[ai] Fix OpenDoc and HyperCard death dates in block-party.mdx

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -679,7 +679,7 @@ Apple stepped up with a vision that aimed to compete with OLE, but took the idea
 
 [OpenDoc diagram]
 
-the first OpenDoc-based product release was Apple's CyberDog web browser in May 1996. It died along with Hypercard in 1997
+the first OpenDoc-based product release was Apple's CyberDog web browser in May 1996. OpenDoc died in 1997, after Steve Jobs returned to Apple and cut it. HyperCard limped on in maintenance mode until Apple finally pulled the plug in 2004.
 
 If we're just going off the promotional videos, OpenDoc is the clear winner in this popularity contest:
 


### PR DESCRIPTION
## Implements

Closes #127

## Parent plan

#110

## What changed

- Replaced the inaccurate sentence "It died along with Hypercard in 1997" with two historically accurate sentences
- Correctly attributes OpenDoc's 1997 cancellation to Steve Jobs returning to Apple
- Correctly states HyperCard continued in maintenance mode and was discontinued by Apple in 2004

## How to verify

- Open `src/content/essays/block-party.mdx` and search for "HyperCard" — the updated text should appear around line 682
- Confirm the phrase "It died along with Hypercard in 1997" no longer exists in the file
- Build/preview the site to confirm the MDX renders without errors

## Notes

Purely a factual correction — no structural or formatting changes. OpenDoc and HyperCard had distinct end dates: OpenDoc was killed in 1997 as part of Steve Jobs' product cuts after returning to Apple, while HyperCard soldiered on in maintenance mode until Apple officially discontinued it in 2004.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176744630/agentic_workflow) for issue #127 · ● 41.6K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176744630, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176744630 -->

<!-- gh-aw-workflow-id: implementer -->