### PR TITLE
[ai] Remove visual placeholder annotations from block-party.mdx

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -374,8 +374,6 @@ to restructure a document without faffing about with precise text selection.
 
 </div>
 
-[visual for drag and drop]
-
 <div style={{display: "inline-block", marginTop: "3rem"}}>
 
 <svg
@@ -509,8 +507,6 @@ To reduce any confusion, let's also make clear what blocks are _not_. Within the
 
 - An entry on a blockchain ledger, or anything to do with Web3 blockchain hype. Please take that party elsewhere.
 - A specific technical implementation; they are not the same as React components, Web Components, or software components. They are a conceptual idea about how we present editable content to end-users of the web.
-
-[cartoon sketch of a block as a higher interface concept, possibly implemented in WC/React/etc, but not concerned with implementation. And nothing to do with the blockchain]
 
 The blocks I am talking about here are an interface pattern. How that pattern is implemented is beyond the scope of this article and my limited knowledge as a pseudo-engineer. I'm interested in blocks from a user and interface designer perspective, rather than a web infrastructure perspective. <Footnote idName={6}>There is plenty to be said about the technical challenges of how we could/should build interoperable blocks built on solid web standards, but I'll leave that to someone else. Perhaps you?</Footnote>
 
@@ -757,8 +753,6 @@ We've already been moving swiftly in this direction in the larger context of fro
 The same will happen with blocks, which are a simply a very specific type of component – one designed for authoring documents on the web.
 
 A big disclaimer on this one. I lead design at HASH, where one of our projects is the Block Protocol – a standardised way for blocks to communicate with their embedding applications (aka. block-editors)
-
-[ diagram ]
 
 I certainly have a vested interest in the block ecosystem diversifying and maturing.
 


### PR DESCRIPTION
## Implements

Closes #128

## Parent plan

#103

## What changed

- Removed `[visual for drag and drop]` placeholder at ~line 377 (and surrounding blank line)
- Removed `[cartoon sketch of block concept]` placeholder at ~line 513 (and surrounding blank line)
- Removed `[ diagram ]` Block Protocol placeholder at ~line 761 (and surrounding blank line)
- All surrounding prose sentences remain untouched

## How to verify

- Open `src/content/essays/block-party.mdx` and confirm no bracket-style placeholder strings remain
- Check that the prose flows cleanly at each cut location with no stray blank lines

## Notes

All three placeholders were bracket-style annotations for visuals that were never created. The surrounding prose was already self-contained, so removal required no other changes.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176744820/agentic_workflow) for issue #128 · ● 63K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176744820, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176744820 -->

<!-- gh-aw-workflow-id: implementer -->