### PR TITLE
[ai] Fix duplicate idName={3} at L483 in block-party.mdx → renumber to idName={7}

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -480,7 +480,7 @@ For example, Roam allows you to embed blocks inside one another and see the back
 
 ---
 
-Like all good software designers, the people creating these new editors are following [Jakob's Law](https://www.nngroup.com/videos/jakobs-law-internet-ux/) of internet user experience; people spend 99% of their time on websites _other than yours_. You'll make their lives far easier if you use design patterns they're already familiar with. While many will grumble the similarities between block-editors speaks to a lack of “innovation”, <Footnote idName={3}> “Innovate” | ˈɪnəveɪt | verb. To flagrantly disregard previous historical work and established conventions that have survived the test of time. Results may vary. </Footnote> the industry converging around a set of standards is a net gain for both users and creators.
+Like all good software designers, the people creating these new editors are following [Jakob's Law](https://www.nngroup.com/videos/jakobs-law-internet-ux/) of internet user experience; people spend 99% of their time on websites _other than yours_. You'll make their lives far easier if you use design patterns they're already familiar with. While many will grumble the similarities between block-editors speaks to a lack of “innovation”, <Footnote idName={7}> “Innovate” | ˈɪnəveɪt | verb. To flagrantly disregard previous historical work and established conventions that have survived the test of time. Results may vary. </Footnote> the industry converging around a set of standards is a net gain for both users and creators.
 
 ## What _exactly_ is a block?
 


### PR DESCRIPTION
## Implements

Closes #125

## Parent plan

#108

## What changed

- In `src/content/essays/block-party.mdx`, changed `idName={3}` → `idName={7}` on L483
- The footnote at L483 ("Innovate" | ˈɪnəveɪt | verb...) was reusing `idName={3}`, which is already assigned to the footnote at L198 (`/` key block picker description)
- `7` is the next available unused integer in this file (existing values: 1, 2, 3, 4, 5, 6, 8, with 1 reused in a separate rendering context at L791)
- All other footnote `idName` values are unchanged

## How to verify

- Search for `idName` in `block-party.mdx` — no two footnotes share the same value
- Visit the block-party essay in the browser; all footnotes should render without errors
- Confirm footnote at L483 displays correctly with its "Innovate" definition text

## Notes

No ambiguity in this change — it's a single-character integer replacement. The `idName={1}` at L791 is intentionally reused per the original analysis (noted as "OK (separate rendering context)"), so it was left untouched.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176735533/agentic_workflow) for issue #125 · ● 69.4K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176735533, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176735533 -->

<!-- gh-aw-workflow-id: implementer -->