### PR TITLE
[ai] Audit block-party.mdx: remove via.placeholder.com URLs

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -324,8 +324,6 @@ Beyond those essentials, its open game. Some editors distinguish themselves by o
 
 There seems to be no ceiling to the complexity level we're willing to wrap up into a single block. Some could be standalone apps in their own right. Kanban boards, image galleries, live coding environments, and fully decked-out spreadsheets that function as relational databases can all be encapsulated into a “block”. This extends to embeds which allow users to stick the whole of Google Maps, Figma, or Airtable into a document.
 
-<RemoteImage src="https://via.placeholder.com/600x300" alt="" />
-
 [spectrum of simple to complex blocks]
 
 <div style={{display: "inline-block", marginTop: "3rem"}}>
@@ -582,10 +580,6 @@ Formatting at the character level gives us an enormous amount of granular contro
 Classical documents might format at the character level, but they organise at the document level. The document is the entity you reference when you link to your work or reference it by name.
 
 A block can be dragged and dropped into a new position on the page. It can be swapped for another type of block without changing its content. It can be copied and pasted into a different document without losing its content and structure.
-
-<RemoteImage src="https://via.placeholder.com/600x300" alt="" />
-
-[annotated diagram of swapping blocks and dragging and dropping blocks]
 
 Blocks open up a world of flexibility and interactive power within a scoped area. They're easier to move around – a key quality for anyone working with ideas who needs to arrange and rearrange information in relationships to find the right groupings and sequences – which is to say, all of us doing knowledge work.
 


### PR DESCRIPTION
## Implements

Closes #135

## Parent plan

#104

## What changed

- Removed `<RemoteImage src="(via.placeholder.com/redacted) alt="" />` at line ~327 (spectrum-of-blocks section)
- Removed `<RemoteImage src="(via.placeholder.com/redacted) alt="" />` and the orphaned `[annotated diagram of swapping blocks and dragging and dropping blocks]` label at lines ~586-588
- Cleaned up surplus blank lines left by each removal
- No other content in the file was touched

## How to verify

- Run `grep -n "via.placeholder.com" src/content/essays/block-party.mdx` — should return zero results
- Read surrounding prose at the two cut sites to confirm no orphaned visual references remain

## Notes

Issue #102 (which was sliced to handle these exact removals) had already been labeled `done`, but the changes were not yet merged into `main`. This PR performs the same removal as part of the verification audit in #135.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176780037/agentic_workflow) for issue #135 · ● 96K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176780037, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176780037 -->

<!-- gh-aw-workflow-id: implementer -->