### PR TITLE
[ai] Replace Gutenberg uncertainty markers with definitive dates in block-party.mdx

### DIFF
--- a/src/content/essays/block-party.mdx
+++ b/src/content/essays/block-party.mdx
@@ -708,7 +708,7 @@ Tumblr was at the height of its popularity. The web was interactive and Web 2.0 
 Notion released version 2.0 in 2018. In this context, despite being the most visible and widely used block-editor to date, Notion was quite late to the game.
 It's undeniable Notion has been the most influential platform championing and pushing the boundaries of block-based editing in recent years.
 
-Wordpress started work on Gutenberg in 2017(?) and released its first version in 2018(?).
+WordPress announced Gutenberg in June 2017 and shipped it as part of WordPress 5.0 on December 6, 2018.
 
 Notion's first release in 2018 kicked things into high gear here. While Wordpress Gutenberg has been out for X years, it served a small use case; writing blog posts. Notion reframed the block editor as an everyday tool – a place to write collaborative documents for your team, or even just yourself. It turned it into an editor you live in, rather than a publishing tool for a specific purpose.
 


### PR DESCRIPTION
## Implements

Closes #131

## Parent plan

#112

## What changed

- Replaced `Wordpress started work on Gutenberg in 2017(?) and released its first version in 2018(?)` with `WordPress announced Gutenberg in June 2017 and shipped it as part of WordPress 5.0 on December 6, 2018.`
- Removed both `(?)` uncertainty markers
- Corrected capitalisation: `Wordpress` → `WordPress`

## How to verify

- Open `src/content/essays/block-party.mdx` and confirm line 711 contains the new sentence with no `(?)` markers
- Run the local dev server and navigate to the Block Party essay — page should render without MDX errors

## Notes

No structural or MDX changes were needed; this was a pure prose correction. The sourced dates (June 2017 announcement, December 6 2018 WordPress 5.0 release) are well-documented.




> Generated by [Implement sub-issue → PR](https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176760780/agentic_workflow) for issue #131 · ● 46.4K · [◷](https://github.com/search?q=repo%3AMaggieAppleton%2Fmaggieappleton.com-V3+%22gh-aw-workflow-id%3A+implementer%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Implement sub-issue → PR, engine: claude, model: claude-sonnet-4-6, id: 25176760780, workflow_id: implementer, run: https://github.com/MaggieAppleton/maggieappleton.com-V3/actions/runs/25176760780 -->

<!-- gh-aw-workflow-id: implementer -->