### PR TITLE
fix: stop planner workflow infinite-looping on agent-created sub-issues

### DIFF
--- a/.github/workflows/planner.lock.yml
+++ b/.github/workflows/planner.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5409948ceeec9abed92035723217d25659a3edc43974129d681630db58b30875","stop_time":"2026-05-25 14:25:22","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"24a95e465225a512472044643937649cd38ee9fda716837f2fc17672fdcb9163","stop_time":"2026-05-25 14:25:22","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"53b83947a5a98c8d113130e565377fae1a50d02f","version":"v6.3.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -53,8 +53,8 @@ name: "Plan issue → sub-issues"
     # names: # Label filtering applied via job conditions
     # - plan # Label filtering applied via job conditions
     types:
-    - opened
     - labeled
+  # skip-if-match: label:plan-processed # Skip-if-match processed as search check in pre-activation job
 
 permissions: {}
 
@@ -180,14 +180,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_731feed35d422f10_EOF'
+          cat << 'GH_AW_PROMPT_79de28428fd7e62d_EOF'
           <system>
-          GH_AW_PROMPT_731feed35d422f10_EOF
+          GH_AW_PROMPT_79de28428fd7e62d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_731feed35d422f10_EOF'
+          cat << 'GH_AW_PROMPT_79de28428fd7e62d_EOF'
           <safe-output-tools>
           Tools: add_comment, create_issue(max:10), add_labels(max:2), link_sub_issue(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -219,12 +219,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_731feed35d422f10_EOF
+          GH_AW_PROMPT_79de28428fd7e62d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_731feed35d422f10_EOF'
+          cat << 'GH_AW_PROMPT_79de28428fd7e62d_EOF'
           </system>
           {{#runtime-import .github/workflows/planner.md}}
-          GH_AW_PROMPT_731feed35d422f10_EOF
+          GH_AW_PROMPT_79de28428fd7e62d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -398,9 +398,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8efe74028dec436c_EOF'
-          {"add_comment":{"max":1},"add_labels":{"allowed":["plan-processed"],"max":2},"create_issue":{"max":10},"create_report_incomplete_issue":{},"link_sub_issue":{"max":10},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_8efe74028dec436c_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_705e287e05589b18_EOF'
+          {"add_comment":{"max":1},"add_labels":{"allowed":["plan-processed"],"max":2},"create_issue":{"labels":["ai-generated"],"max":10},"create_report_incomplete_issue":{},"link_sub_issue":{"max":10},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_705e287e05589b18_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -408,7 +408,7 @@ jobs:
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading.",
                 "add_labels": " CONSTRAINTS: Maximum 2 label(s) can be added. Only these labels are allowed: [\"plan-processed\"].",
-                "create_issue": " CONSTRAINTS: Maximum 10 issue(s) can be created.",
+                "create_issue": " CONSTRAINTS: Maximum 10 issue(s) can be created. Labels [\"ai-generated\"] will be automatically added.",
                 "link_sub_issue": " CONSTRAINTS: Maximum 10 sub-issue link(s) can be created."
               },
               "repo_params": {},
@@ -656,7 +656,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
-          cat << GH_AW_MCP_CONFIG_3ef4e7ee81313de9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_5a7030fe1296db69_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -696,7 +696,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3ef4e7ee81313de9_EOF
+          GH_AW_MCP_CONFIG_5a7030fe1296db69_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1251,7 +1251,7 @@ jobs:
     permissions:
       actions: read
     outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_stop_time.outputs.stop_time_ok == 'true' && steps.check_rate_limit.outputs.rate_limit_ok == 'true' }}
+      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_stop_time.outputs.stop_time_ok == 'true' && steps.check_skip_if_match.outputs.skip_check_ok == 'true' && steps.check_rate_limit.outputs.rate_limit_ok == 'true' }}
       matched_command: ''
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
     steps:
@@ -1299,6 +1299,19 @@ jobs:
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_stop_time.cjs');
+            await main();
+      - name: Check skip-if-match query
+        id: check_skip_if_match
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          GH_AW_SKIP_QUERY: "label:plan-processed"
+          GH_AW_WORKFLOW_NAME: "Plan issue → sub-issues"
+          GH_AW_SKIP_MAX_MATCHES: "1"
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_skip_if_match.cjs');
             await main();
 
   safe_outputs:
@@ -1373,7 +1386,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"plan-processed\"],\"max\":2},\"create_issue\":{\"max\":10},\"create_report_incomplete_issue\":{},\"link_sub_issue\":{\"max\":10},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"add_labels\":{\"allowed\":[\"plan-processed\"],\"max\":2},\"create_issue\":{\"labels\":[\"ai-generated\"],\"max\":10},\"create_report_incomplete_issue\":{},\"link_sub_issue\":{\"max\":10},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/planner.md
+++ b/.github/workflows/planner.md
@@ -2,8 +2,10 @@
 name: Plan issue → sub-issues
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
     names: [plan]
+  # Don't re-plan an issue we've already processed.
+  skip-if-match: 'label:plan-processed'
   stop-after: "+30d"
 permissions:
   contents: read
@@ -22,9 +24,10 @@ tools:
 safe-outputs:
   create-issue:
     max: 10
-    # Labels the agent is allowed to put on sub-issues.
-    # The agent chooses one of `ready-to-implement` or `needs-human-answer`
-    # per sub-issue.
+    # Auto-applied to every sub-issue so downstream automation can
+    # recognise machine-authored content. The agent additionally chooses
+    # one of `ready-to-implement` or `needs-human-answer` per sub-issue.
+    labels: [ai-generated]
   link-sub-issue:
     max: 10
   add-labels:
@@ -101,6 +104,8 @@ Each `create-issue` must use this body format:
 ```
 
 ## Labels
+
+Every sub-issue is automatically tagged `ai-generated` by the workflow — you don't need to add that yourself.
 
 Apply exactly **one** of these labels to each sub-issue via the `labels` field on `create-issue`:
 - `ready-to-implement`


### PR DESCRIPTION
## Summary

The planner agentic workflow triggered on `issues: types: [opened, labeled]`, which fired on every sub-issue it created via `safe-outputs.create-issue` — each new sub-issue re-fired the planner, producing runaway recursion (~100 issues / ~100 PRs in the last incident). The implementer downstream then opened a PR per sub-issue, amplifying the blast radius.

## Changes

- Restrict the planner trigger to `types: [labeled]` so only a human-applied `plan` label fires it. Sub-issues created by the workflow fire `opened` events, which are now ignored.
- Re-add `skip-if-match: 'label:plan-processed'` for idempotency on re-labeling.
- Auto-tag every agent-created sub-issue with `ai-generated` per the gh-aw [ResearchPlanAssignOps pattern](https://github.github.com/gh-aw/patterns/research-plan-assign-ops/) for defence in depth.
- Regenerate `planner.lock.yml` via `gh aw compile`.

## Test plan

- [ ] Open a fresh test issue with no labels — planner should NOT fire.
- [ ] Apply the `plan` label — planner SHOULD fire and emit sub-issues.
- [ ] Confirm sub-issues do NOT re-trigger the planner (Actions tab shows one planner run only).
- [ ] Confirm sub-issues carry `ai-generated` plus one of `ready-to-implement` / `needs-human-answer`.
- [ ] Close stale auto-created issues/PRs from the prior incident before re-enabling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)