### PR TITLE
fix: allow all HTTPS image sources in CSP for webmention avatars

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,7 +25,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://platform.twitter.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://res.cloudinary.com https://*.twimg.com https://pbs.twimg.com https://i.ytimg.com https://media.maggieappleton.com https://avatars.webmention.io https://d2eip9sf3oo6c2.cloudfront.net https://*.cdn.getcloudapp.com; font-src 'self' https://fonts.gstatic.com; media-src 'self' https://media.maggieappleton.com; frame-src https://twitter.com https://platform.twitter.com https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://www.figma.com https://share.transistor.fm; connect-src 'self' https://syndication.twitter.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://platform.twitter.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; media-src 'self' https://media.maggieappleton.com; frame-src https://twitter.com https://platform.twitter.com https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://www.figma.com https://share.transistor.fm; connect-src 'self' https://syndication.twitter.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Webmention author photos render as broken images because the CSP `img-src` allowlist in `vercel.json` only included `avatars.webmention.io`, while actual photos come from `cdn.bsky.app`, `david.garden`, `social.yesterweb.org`, and other arbitrary IndieWeb domains.
- Replaced the explicit allowlist with `https:` since enumerating every possible webmention domain isn't maintainable. Other CSP directives (`script-src`, `connect-src`, `frame-src`) remain strict.

## Test plan
- [ ] Deploy preview, open a post with webmentions, confirm avatars load
- [ ] Verify no CSP violations in DevTools console