### PR TITLE
fix: update site branding to amhhei Appleton

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,11 +31,11 @@ const sortedPatterns = patterns
 	.slice(0, 8);
 ---
 
-<Layout title="Maggie Appleton">
+<Layout title="amhhei Appleton">
 	<PageWrapper>
 		<header class="page-header">
 			<Title1 class="main-title">
-				<b>Maggie </b>
+				<b>amhhei </b>
 				makes visual essays about programming, design, and anthropology.
 			</Title1>
 			<SmallTitle2>


### PR DESCRIPTION
Updated the site title and main header name throughout the index page and Title1 component. Changed the layout title prop and the bold name text from 'Maggie' to 'amhhei' to reflect the new branding.

> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/MaggieAppleton/maggieappleton.com-V3/01KTPD9YWB8NK8CVPCC4Z6N302)