### PR TITLE
feat(menu): add ARIA attributes to mobile menu

### DIFF
--- a/src/components/layouts/navbar/MobileMenu.astro
+++ b/src/components/layouts/navbar/MobileMenu.astro
@@ -2,7 +2,7 @@
 import { Icon } from "astro-icon/components";
 ---
 
-<div id="mobile-menu" class="mobile-menu">
+<div id="mobile-menu" class="mobile-menu" role="dialog" aria-label="Navigation menu">
 	<nav class="mobile-nav">
 		<a href="/garden" class="nav-link">The Garden</a>
 		<a href="/essays" class="nav-link">Essays</a>
@@ -81,6 +81,11 @@ import { Icon } from "astro-icon/components";
 		const closeMobileMenu = () => {
 			mobileMenu.classList.remove("open");
 			document.body.style.overflow = "auto";
+			const menuToggle = document.getElementById("mobile-menu-toggle");
+			if (menuToggle) {
+				menuToggle.classList.remove("open");
+				menuToggle.setAttribute("aria-expanded", "false");
+			}
 		};
 
 		const handleLinkClick = (e: Event) => {

--- a/src/components/layouts/navbar/Navbar.astro
+++ b/src/components/layouts/navbar/Navbar.astro
@@ -15,7 +15,9 @@ import { Icon } from "astro-icon/components";
 		<button
 			id="mobile-menu-toggle"
 			class="mobile-menu-toggle"
-			aria-label="Toggle mobile menu"
+			aria-label="Menu"
+			aria-expanded="false"
+			aria-controls="mobile-menu"
 		>
 			<Icon name="heroicons:bars-3" size={28} class="menu-icon" />
 			<Icon name="heroicons:x-mark" size={28} class="close-icon" />
@@ -119,7 +121,10 @@ import { Icon } from "astro-icon/components";
 			newMenuToggle.classList.toggle("open");
 			mobileMenu.classList.toggle("open");
 
-			if (mobileMenu.classList.contains("open")) {
+			const isOpen = mobileMenu.classList.contains("open");
+			newMenuToggle.setAttribute("aria-expanded", String(isOpen));
+
+			if (isOpen) {
 				document.body.style.overflow = "hidden";
 			} else {
 				document.body.style.overflow = "auto";


### PR DESCRIPTION
Enhanced accessibility of the mobile menu component by adding proper ARIA attributes to improve screen reader support.

Changes:
- Added `role`, `aria-label`, and `aria-controls` attributes to the mobile menu container
- Added `aria-label` and `aria-expanded` attributes to the toggle button
- Updated the close menu handler to properly update the toggle button's `aria-expanded` state
- Ensured the open class is removed when the menu closes

These changes ensure screen readers can properly interpret the menu state and the relationship between the toggle button and menu container.

> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/MaggieAppleton/maggieappleton.com-V3/01KTXY91HR11YBZ8NKKPX2WN40)