### PR TITLE
fix(alert): add semantic ARIA attributes to icon

### DIFF
--- a/src/components/mdx/Alert.astro
+++ b/src/components/mdx/Alert.astro
@@ -9,7 +9,10 @@ const { title } = Astro.props;
 		fill="none"
 		preserveAspectRatio="xMinYMin meet"
 		xmlns="http://www.w3.org/2000/svg"
+		role="img"
+		aria-labelledby="alert-icon-title"
 	>
+		<title id="alert-icon-title">Warning</title>
 		<path
 			fill-rule="evenodd"
 			clip-rule="evenodd"


### PR DESCRIPTION
Enhanced accessibility of the Alert component by adding semantic ARIA attributes to the SVG icon.

Changes:
- Added `role="img"` to the SVG element to identify it as an image
- Added `aria-labelledby` attribute pointing to the icon's title
- Added `<title>` element with `id="alert-icon-title"` containing "Warning" text

This ensures screen readers properly announce the icon's purpose and improves overall component accessibility.

> Created by **GitHub Ace** · [View Session](https://ace.githubnext.com/MaggieAppleton/maggieappleton.com-V3/01KTXYE17SVGW6NF5188A46GVG)