### PR TITLE
Make growth stage label interactive

### DIFF
--- a/src/components/layouts/GrowthStage.astro
+++ b/src/components/layouts/GrowthStage.astro
@@ -18,13 +18,17 @@ const tooltipContent = {
 ---
 
 <Tooltip maxWidth={300}>
-	<p class="growth-stage">{stage}</p>
+	<button type="button" class="growth-stage">{stage}</button>
 	<p slot="content">{tooltipContent[stage]}</p>
 </Tooltip>
 
 <style>
 	.growth-stage {
-		display: inline-block;
+		display: inline-flex;
+		align-items: center;
+		appearance: none;
+		border: 0;
+		background: transparent;
 		cursor: pointer;
 		font-family: var(--font-sans);
 		font-size: var(--font-size-xs);
@@ -32,6 +36,13 @@ const tooltipContent = {
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		font-weight: bold;
-		padding-right: var(--space-xs);
+		margin: 0;
+		padding: 0;
+	}
+
+	.growth-stage:focus-visible {
+		outline: 2px solid var(--color-medium-sea-blue);
+		outline-offset: 3px;
+		border-radius: 2px;
 	}
 </style>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -7,6 +7,7 @@ import Backlinks from "../components/layouts/Backlinks.astro";
 import WebMentions from "../components/layouts/WebMentions.astro";
 import linkMaps from "../links.json";
 import GrowthIcon from "../components/layouts/GrowthIcon.astro";
+import GrowthStage from "../components/layouts/GrowthStage.astro";
 import Dates from "../components/layouts/Dates.astro";
 import Topics from "../components/layouts/Topics.astro";
 import VersionWarning from "../components/layouts/VersionWarning.astro";
@@ -98,7 +99,7 @@ const updatedISO =
 				size="16"
 				growthStage={frontmatter.growthStage as "budding" | "evergreen" | "seedling"}
 			/>
-			<p>{frontmatter.growthStage}</p>
+			<GrowthStage stage={frontmatter.growthStage as "budding" | "evergreen" | "seedling"} />
 			{frontmatter.draft && <span class="draft-label">Draft</span>}
 		</div>
 		<div class="title-container">


### PR DESCRIPTION
## Summary
- Render the growth stage label as a button inside the tooltip component.
- Add focus-visible styling so the label is keyboard accessible.
- Reuse the new `GrowthStage` component in post layouts instead of a plain paragraph.

## Testing
- Not run (not requested)