### PR TITLE
Fix responsive overflow and uneven gutters

### DIFF
--- a/src/components/layouts/ProseWrapper.astro
+++ b/src/components/layouts/ProseWrapper.astro
@@ -8,6 +8,7 @@
 		grid-template-columns: 1fr min(72ch, 100%) 1fr;
 		counter-reset: footnote-counter;
 		font-size: var(--font-size-base);
+		overflow-wrap: anywhere;
 	}
 
 	.prose-wrapper > :global(*) {

--- a/src/components/mdx/AssumedAudience.astro
+++ b/src/components/mdx/AssumedAudience.astro
@@ -38,9 +38,14 @@
 			letter-spacing: 0.05rem;
 		}
 
+		@media (max-width: 864px) {
+			.assumed-audience {
+				margin: 0 0 var(--space-m);
+			}
+		}
+
 		@media (max-width: 768px) {
 			.assumed-audience {
-				margin: 0 0 var(--space-m) 0;
 				flex-direction: column;
 				gap: var(--space-3xs);
 			}

--- a/src/components/mdx/RemoteImage.astro
+++ b/src/components/mdx/RemoteImage.astro
@@ -32,7 +32,7 @@ const widthWithUnit = typeof width === "number" ? `${width}px` : width;
 >
 	<div
 		class:list={["image-wrapper", { "image-frame": framed }]}
-		style={`width: ${widthWithUnit}`}
+		style={`width: 100%; max-width: ${widthWithUnit}`}
 	>
 		<img src={src} alt={alt} loading="lazy" />
 	</div>

--- a/src/components/search/GardenFilters.astro
+++ b/src/components/search/GardenFilters.astro
@@ -198,7 +198,7 @@ const TYPES = [
 			display: inline-block;
 		}
 	}
-	@media (max-width: 500px) {
+	@media (max-width: 576px) {
 		.mobile-topics.filter-popover {
 			width: 100%;
 		}
@@ -214,7 +214,7 @@ const TYPES = [
 			justify-content: center;
 		}
 	}
-	@media (max-width: 500px) {
+	@media (max-width: 576px) {
 		.right-menus {
 			flex-direction: column;
 		}
@@ -224,7 +224,7 @@ const TYPES = [
 		position: relative;
 		display: inline-block;
 	}
-	@media (max-width: 500px) {
+	@media (max-width: 576px) {
 		.filter-popover {
 			width: 100%;
 		}
@@ -253,7 +253,7 @@ const TYPES = [
 			border-color 0.2s ease,
 			color 0.2s ease;
 	}
-	@media (max-width: 500px) {
+	@media (max-width: 576px) {
 		.filter-trigger {
 			width: 100%;
 		}

--- a/src/components/unique/TweenBox.astro
+++ b/src/components/unique/TweenBox.astro
@@ -34,6 +34,8 @@
 <style>
 	.box-container {
 		margin: 2em;
+		container-type: inline-size;
+		overflow-x: clip;
 	}
 
 	.animated-box {
@@ -49,7 +51,7 @@
 	}
 
 	.animated-box.slide-in {
-		transform: translateX(400px);
+		transform: translateX(min(400px, calc(100cqw - 120px)));
 		opacity: 1;
 	}
 </style>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -208,6 +208,13 @@ const updatedISO =
 		width: 100%;
 	}
 
+	@media (max-width: 864px) {
+		.styled-main,
+		.header-section {
+			padding-inline: var(--space-xs);
+		}
+	}
+
 	@media (max-width: 768px) {
 		.metadata {
 			flex-direction: column;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -325,6 +325,12 @@ const sortedPatterns = patterns
 		margin-left: -1.4rem;
 	}
 
+	@media (max-width: 576px) {
+		.patterns-grid {
+			margin-left: calc(-1 * var(--space-xs));
+		}
+	}
+
 	.library-section {
 		grid-area: library;
 	}
@@ -332,13 +338,13 @@ const sortedPatterns = patterns
 	.essays-grid,
 	.books-grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
 		grid-gap: var(--space-2xs);
 	}
 
 	.books-grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr));
 		grid-gap: var(--space-2xs);
 		margin: 0;
 	}

--- a/src/pages/now-[slug].astro
+++ b/src/pages/now-[slug].astro
@@ -176,6 +176,12 @@ const components = {
 		transform: translate3d(3px, 0, 0);
 	}
 
+	@media (max-width: 1064px) {
+		.header-section {
+			width: calc(100% - 2 * var(--space-m));
+		}
+	}
+
 	@media (max-width: 768px) {
 		.now-layout {
 			grid-template-columns: 1fr;
@@ -190,6 +196,7 @@ const components = {
 		}
 
 		.header-section {
+			width: 100%;
 			padding: 0 var(--space-xs);
 		}
 	}


### PR DESCRIPTION
## Summary

- make homepage grids and garden filters shrink or stack cleanly at narrow widths
- preserve symmetric post, callout, and Now-detail gutters across breakpoint seams
- allow pathological prose tokens and authored remote images to shrink within their containers
- cap the GreenSock tutorial animation to its local track instead of widening the document

## Visual audit

Checked with Playwright MCP screenshots and DOM geometry across:

- homepage, garden, about, and Now
- two representative essays and one representative note
- 390×844 and 430×932 iPhone-sized viewports
- 360×800 and 412×915 Android-sized viewports
- 768×1024 and 820×1180 tablet viewports
- targeted 320, 540, 577, 769, 1064, and 1065px breakpoint probes
- a Now detail page and the intentional full-bleed /in-memoriam page

Final scrolled layout matrix: **52/52 passing**, with no document-level horizontal overflow and symmetric outer layout gutters.

## Verification

- `npm run build:local` — passes
- mobile ClientRouter navigation from `/` to `/garden` — menu closes, body scrolling restores, zero overflow
- lazy-loaded 850–1100px remote images at 820px — zero overflow
- independent Terra implementation/self-review and Luna spec/quality review — pass, no remaining findings
