### PR TITLE
Shrink and widen pull quotes for long excerpts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import icon from "astro-icon";
 import { remarkWikiLink } from "./src/plugins/remark-wiki-link";
+import { remarkLongBlockquote } from "./src/plugins/remark-long-blockquote";
 
 // https://astro.build/config
 export default defineConfig({
@@ -13,7 +14,7 @@ export default defineConfig({
   },
   integrations: [
     mdx({
-      remarkPlugins: [remarkWikiLink],
+      remarkPlugins: [remarkWikiLink, remarkLongBlockquote],
       shikiConfig: {
         theme: "night-owl",
         wrap: true,

--- a/src/components/layouts/ProseWrapper.astro
+++ b/src/components/layouts/ProseWrapper.astro
@@ -135,6 +135,14 @@
 		display: inline-block;
 	}
 
+	/* Long excerpts get a smaller, wider treatment so they don't turn into
+	   a tall column of oversized text. See remarkLongBlockquote. */
+	.prose-wrapper :global(blockquote.long-quote > p) {
+		max-width: 60ch;
+		font-size: var(--font-size-md);
+		line-height: var(--leading-looser);
+	}
+
 	.prose-wrapper :global(blockquote::before),
 	.prose-wrapper :global(blockquote::after) {
 		content: "";

--- a/src/plugins/remark-long-blockquote.js
+++ b/src/plugins/remark-long-blockquote.js
@@ -1,0 +1,31 @@
+import { visit } from "unist-util-visit";
+
+// Pull quotes are styled large and narrow by default, which looks great for a
+// short line or two but turns a long excerpt into a tall column of oversized
+// text. Anything past this length gets a `long-quote` class so it can be
+// rendered smaller and wider instead.
+const LONG_QUOTE_THRESHOLD = 350;
+
+function getTextLength(node) {
+	if (node.type === "text") return node.value.length;
+	if (!node.children) return 0;
+	return node.children.reduce((total, child) => total + getTextLength(child), 0);
+}
+
+export function remarkLongBlockquote() {
+	return (tree) => {
+		visit(tree, "blockquote", (node) => {
+			if (getTextLength(node) <= LONG_QUOTE_THRESHOLD) return;
+
+			node.data ??= {};
+			node.data.hProperties ??= {};
+			const existingClassName = node.data.hProperties.className;
+			const classes = Array.isArray(existingClassName)
+				? existingClassName
+				: existingClassName
+					? [existingClassName]
+					: [];
+			node.data.hProperties.className = [...classes, "long-quote"];
+		});
+	};
+}


### PR DESCRIPTION
## Summary

- Long pull quotes (like the "I Want a Wife" excerpt in the June now-page) were rendering with the same `max-width: 30ch` / `font-size-lg` treatment as short one-liners, turning them into a tall column of oversized text.
- Added a remark plugin (`src/plugins/remark-long-blockquote.js`) that measures blockquote text length at build time and tags anything over 350 characters with a `long-quote` class (threshold picked from the actual distribution of quotes across the site — a natural gap sits between ~340 and ~630 chars).
- Added conditional CSS in `ProseWrapper.astro` so `.long-quote` blockquotes render at `font-size-md` with a `60ch` max-width and looser line-height, while short quotes keep their existing large/narrow styling.

## Test plan

- [x] `npm run build:local` completes successfully
- [x] Verified `dist/now-2026-06/index.html` renders `<blockquote class="long-quote">` for the long excerpt
- [x] Verified short quotes elsewhere (e.g. `/apps`, `/garden-history`) still render as plain `<blockquote>` with unchanged styling

---
_Generated by [Claude Code](https://claude.ai/code/session_017VSEopEqRz6NdHDhv1Rxn7)_