### PR TITLE
Fix Topics label vertical alignment

### DIFF
--- a/src/components/search/GardenFilters.astro
+++ b/src/components/search/GardenFilters.astro
@@ -454,6 +454,7 @@ const TYPES = [
 	.topics-container {
 		display: flex;
 		flex-direction: row;
+		align-items: center;
 		flex: 1;
 		min-width: 0;
 	}


### PR DESCRIPTION
## Summary
- vertically center the Topics label alongside the topic chips

## Verification
- node regression check for the centered topics row
- npm run build:local
- browser layout measurement confirms 0px vertical-center delta
- independent subagent review: no issues found